### PR TITLE
Add CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,72 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(spz
+  DESCRIPTION "A 3D Gaussians format"
+  LANGUAGES C CXX
+  VERSION 1.1.0)
+
+include(GNUInstallDirs)
+
+# zlib is required to build the project
+find_package(ZLIB REQUIRED)
+
+set(spz_sources
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/cc/load-spz.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/cc/splat-c-types.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/cc/splat-types.cc"
+)
+
+set(spz_headers
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/cc/load-spz.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/cc/splat-c-types.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/cc/splat-types.h"
+)
+
+# create the library and configure it
+add_library(spz ${spz_sources})
+
+target_link_libraries(spz PRIVATE ZLIB::ZLIB)
+
+target_include_directories(spz
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/cc>
+  INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+set_target_properties(spz PROPERTIES
+  PUBLIC_HEADER "${spz_headers}"
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED ON
+)
+
+# Installation
+
+## Install spzConfig.cmake spz::spz target can be found when calling find_package(spz)
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/spzConfig.cmake.in"
+  "${CMAKE_BINARY_DIR}/cmake/spzConfig.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/spz")
+write_basic_package_version_file(
+  "${CMAKE_BINARY_DIR}/cmake/spzConfigVersion.cmake"
+  VERSION "${spz_VERSION}"
+  COMPATIBILITY SameMajorVersion)
+install(
+  FILES
+    "${CMAKE_BINARY_DIR}/cmake/spzConfig.cmake"
+    "${CMAKE_BINARY_DIR}/cmake/spzConfigVersion.cmake"
+  DESTINATION
+    "${CMAKE_INSTALL_LIBDIR}/cmake/spz"
+)
+
+install(TARGETS spz
+  EXPORT spzTargets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(EXPORT spzTargets
+  NAMESPACE spz::
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/spz"
+)

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ be saved and loaded without conversion, which may harm interoperability.
 
 ### C++
 
-Requires `libz` as the only dependent library, otherwise the code is completely self-contained. No
-build system is provided (bring your own build).
+Requires `libz` as the only dependent library, otherwise the code is completely self-contained.
+A CMake build system is provided for convenience.
 
 ## API
 

--- a/cmake/spzConfig.cmake.in
+++ b/cmake/spzConfig.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/spzConfigVersion.cmake)
+message(STATUS "Found spz ${PACKAGE_VERSION}")
+
+include(${CMAKE_CURRENT_LIST_DIR}/spzTargets.cmake)
+
+check_required_components(spz)

--- a/src/cc/splat-types.h
+++ b/src/cc/splat-types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstdint>


### PR DESCRIPTION
Simplify compilation using CMake.
Added the standard installation step for easy integration by the user.
Also added a missing <algorithm> header required for std::sort