### PR TITLE
Fix for Windows and CPP17 compatibility

### DIFF
--- a/src/cc/load-spz.cc
+++ b/src/cc/load-spz.cc
@@ -222,12 +222,11 @@ PackedGaussians packGaussians(const GaussianCloud &g, const PackOptions &o) {
 
   // Use 12 bits for the fractional part of coordinates (~0.25 millimeter resolution). In the future
   // we can use different values on a per-splat basis and still be compatible with the decoder.
-  PackedGaussians packed = {
-    .numPoints = g.numPoints,
-    .shDegree = g.shDegree,
-    .fractionalBits = 12,
-    .antialiased = g.antialiased,
-  };
+  PackedGaussians packed;
+  packed.numPoints = g.numPoints;
+  packed.shDegree = g.shDegree;
+  packed.fractionalBits = 12;
+  packed.antialiased = g.antialiased;
   packed.positions.resize(numPoints * 3 * 3);
   packed.scales.resize(numPoints * 3);
   packed.rotations.resize(numPoints * 3);
@@ -390,11 +389,10 @@ GaussianCloud unpackGaussians(const PackedGaussians &packed, const UnpackOptions
     return {};
   }
 
-  GaussianCloud result = {
-    .numPoints = packed.numPoints,
-    .shDegree = packed.shDegree,
-    .antialiased = packed.antialiased,
-  };
+  GaussianCloud result;
+  result.numPoints = packed.numPoints;
+  result.shDegree = packed.shDegree;
+  result.antialiased = packed.antialiased;
   result.positions.resize(numPoints * 3);
   result.scales.resize(numPoints * 3);
   result.rotations.resize(numPoints * 4);
@@ -453,12 +451,11 @@ GaussianCloud unpackGaussians(const PackedGaussians &packed, const UnpackOptions
 }
 
 void serializePackedGaussians(const PackedGaussians &packed, std::ostream *out) {
-  PackedGaussiansHeader header = {
-    .numPoints = static_cast<uint32_t>(packed.numPoints),
-    .shDegree = static_cast<uint8_t>(packed.shDegree),
-    .fractionalBits = static_cast<uint8_t>(packed.fractionalBits),
-    .flags = static_cast<uint8_t>(packed.antialiased ? FlagAntialiased : 0),
-  };
+  PackedGaussiansHeader header;
+  header.numPoints = static_cast<uint32_t>(packed.numPoints);
+  header.shDegree = static_cast<uint8_t>(packed.shDegree);
+  header.fractionalBits = static_cast<uint8_t>(packed.fractionalBits);
+  header.flags = static_cast<uint8_t>(packed.antialiased ? FlagAntialiased : 0);
   out->write(reinterpret_cast<const char *>(&header), sizeof(header));
   out->write(reinterpret_cast<const char *>(packed.positions.data()), countBytes(packed.positions));
   out->write(reinterpret_cast<const char *>(packed.alphas.data()), countBytes(packed.alphas));
@@ -492,11 +489,11 @@ PackedGaussians deserializePackedGaussians(std::istream &in) {
   const int32_t numPoints = header.numPoints;
   const int32_t shDim = dimForDegree(header.shDegree);
   const bool usesFloat16 = header.version == 1;
-  PackedGaussians result = {
-    .numPoints = numPoints,
-    .shDegree = header.shDegree,
-    .fractionalBits = header.fractionalBits,
-    .antialiased = (header.flags & FlagAntialiased) != 0};
+  PackedGaussians result;
+  result.numPoints = numPoints;
+  result.shDegree = header.shDegree;
+  result.fractionalBits = header.fractionalBits;
+  result.antialiased = (header.flags & FlagAntialiased) != 0;
   result.positions.resize(numPoints * 3 * (usesFloat16 ? 2 : 3));
   result.scales.resize(numPoints * 3);
   result.rotations.resize(numPoints * 3);

--- a/src/cc/splat-c-types.h
+++ b/src/cc/splat-c-types.h
@@ -1,6 +1,8 @@
 #ifndef SPZ_SPLAT_C_TYPES_H_
 #define SPZ_SPLAT_C_TYPES_H_
 
+#define _USE_MATH_DEFINES
+#include <math.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/cc/splat-types.cc
+++ b/src/cc/splat-types.cc
@@ -1,6 +1,7 @@
 #include "splat-types.h"
 
 #include <cmath>
+#include <limits>
 
 namespace spz {
 
@@ -17,7 +18,7 @@ float halfToFloat(Half h) {
 
   if (exponent == 31) {
     // Infinity or NaN.
-    return mantissa != 0 ? 0.0f / 0.0f : signMul * 1.0f / 0.0f;
+    return mantissa != 0 ? std::numeric_limits<float>::quiet_NaN() : signMul * std::numeric_limits<float>::infinity();
   }
 
   // non-zero exponent implies 1 in the mantissa decimal.

--- a/src/cc/splat-types.h
+++ b/src/cc/splat-types.h
@@ -57,27 +57,26 @@ constexpr CoordinateConverter coordinateConverter(CoordinateSystem from, Coordin
   float x = xMatch ? 1.0f : -1.0f;
   float y = yMatch ? 1.0f : -1.0f;
   float z = zMatch ? 1.0f : -1.0f;
-  return {
-    .flipP = {x, y, z},
-    .flipQ = {y * z, x * z, x * y},
-    .flipSh =
-      {
-        y,          // 0
-        z,          // 1
-        x,          // 2
-        x * y,      // 3
-        y * z,      // 4
-        1.0f,       // 5
-        x * z,      // 6
-        1.0f,       // 7
-        y,          // 8
-        x * y * z,  // 9
-        y,          // 10
-        z,          // 11
-        x,          // 12
-        z,          // 13
-        x,          // 14
-      },
+  return CoordinateConverter{
+    {x, y, z},
+    {y * z, x * z, x * y},
+    {
+      y,          // 0
+      z,          // 1
+      x,          // 2
+      x * y,      // 3
+      y * z,      // 4
+      1.0f,       // 5
+      x * z,      // 6
+      1.0f,       // 7
+      y,          // 8
+      x * y * z,  // 9
+      y,          // 10
+      z,          // 11
+      x,          // 12
+      z,          // 13
+      x           // 14
+    }
   };
 }
 

--- a/src/cc/splat-types.h
+++ b/src/cc/splat-types.h
@@ -232,7 +232,7 @@ constexpr Vec3f times(const Quat4f &q, const Vec3f &p) {
     vx * (xz2 - wy2) + vy * (yz2 + wx2) + vz * (1.0f - (xx2 + yy2))};
 }
 
-constexpr Quat4f times(const Quat4f &a, const Quat4f &b) {
+inline Quat4f times(const Quat4f &a, const Quat4f &b) {
   auto [w, x, y, z] = a;
   auto [qw, qx, qy, qz] = b;
   return normalized(std::array<float, 4>{


### PR DESCRIPTION
- Member initializer is a C++20 feature. However, as suggested by the [VFX reference platform](https://vfxplatform.com/), many toolchains still use C++17. In this PR, we make the code C++17 compatible.
- Fixed a "divide by zero" compilation error on MSVC/VS2022 on Windows.
- Fixed a missing header for `std::sort` and function `Quat4f times(const Quat4f &a, const Quat4f &b)` cannot return a `constexpr` with MSVC compiler.