### PR TITLE
Fix file format description in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Loads a cloud of Gaussians from a file in `.spz` format.
 
 The .spz format is a gzipped stream of data consisting of a 16-byte header followed by the
 gaussian data. This data is organized by attribute in the following order: positions,
-scales, rotations, alphas, colors, spherical harmonics.
+alphas, colors, scales, rotations, spherical harmonics.
 
 ### Header
 


### PR DESCRIPTION
The order of data components in the file was listed wrong. Make it match what the load/save code actually does.