### PR TITLE
fix boundary issue in PackedGaussians::at(int i)

### DIFF
--- a/src/cc/load-spz.cc
+++ b/src/cc/load-spz.cc
@@ -343,9 +343,9 @@ PackedGaussian PackedGaussians::at(int i) const {
   int start3 = i * 3;
   const auto *p = &positions[i * positionBits];
   std::copy(p, p + positionBits, result.position.data());
-  std::copy(&scales[start3], &scales[start3 + 3], result.scale.data());
-  std::copy(&rotations[start3], &rotations[start3 + 3], result.rotation.data());
-  std::copy(&colors[start3], &colors[start3 + 3], result.color.data());
+  std::copy(&scales[start3], &scales[start3] + 3, result.scale.data());
+  std::copy(&rotations[start3], &rotations[start3] + 3, result.rotation.data());
+  std::copy(&colors[start3], &colors[start3] + 3, result.color.data());
   result.alpha = alphas[i];
 
   int shDim = dimForDegree(shDegree);


### PR DESCRIPTION
This fixes the issue I noticed in https://github.com/nianticlabs/spz/issues/17

The problem with the previous implementation is that if scales[start3 +3] is bounds checked (maybe only in Release or not at all in a compiler different than mine = VS2022), this will raise an error instead of giving the offsetted pointer as intended.

I think the the current implementation is undefined behaviour that accidentally works in most settings.

My fix uses pointer arthetic, which is not so elegant, but in this case I think it is valid to use it.