### PR TITLE
more accurate quaternion quantization

### DIFF
--- a/src/cc/load-spz.h
+++ b/src/cc/load-spz.h
@@ -59,6 +59,7 @@ struct PackedGaussians {
 
 struct PackOptions {
   CoordinateSystem from = CoordinateSystem::UNSPECIFIED;
+  bool fast_rot_quantization = false;
 };
 
 struct UnpackOptions {


### PR DESCRIPTION
Works by taking the nearest neighbor (in quantized xyz space) that has the smallest reconstruction error.

Previous code could cause large errors at reconstruction time (see https://github.com/nianticlabs/spz/issues/31)

fixes https://github.com/nianticlabs/spz/issues/31