### PR TITLE
Python bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,47 @@
 .DS_Store
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+venv/
+env/
+ENV/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# CMake
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+*.cmake

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include README.md
+include LICENSE
+include *.txt
+include *.md
+include *.toml
+recursive-include src/cc *.h *.cc
+recursive-include python *.py *.cpp
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co] 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,84 @@ be saved and loaded without conversion, which may harm interoperability.
 
 ## Implementations
 
+### Python
+
+Install via pip:
+
+```bash
+pip install spz
+```
+
+#### Usage
+
+The SPZ Python package provides bidirectional conversion between PLY and SPZ formats:
+
+```python
+import spz
+
+# Convert a PLY file to SPZ format (compression)
+success = spz.ply_to_spz("input.ply", "output.spz", coordinate_system="RDF")
+if success:
+    print("Compression successful!")
+
+# Convert an SPZ file back to PLY format (decompression)
+success = spz.spz_to_ply("input.spz", "output.ply", coordinate_system="RDF")
+if success:
+    print("Decompression successful!")
+
+# Roundtrip example: PLY → SPZ → PLY
+spz.ply_to_spz("original.ply", "compressed.spz", coordinate_system="RDF")
+spz.spz_to_ply("compressed.spz", "restored.ply", coordinate_system="RDF")
+```
+
+**Coordinate Systems**: The `coordinate_system` parameter specifies the coordinate system:
+- `"RDF"` - Right Down Front (typical PLY format, **default**)
+- `"RUB"` - Right Up Back (Three.js/OpenGL format)
+- `"LUF"` - Left Up Front (GLB format)
+- `"RUF"` - Right Up Front (Unity format)
+- `"UNSPECIFIED"` - No coordinate conversion
+
+**Compression Performance**: SPZ typically achieves 10-15x compression ratios with minimal quality loss.
+
+#### Development Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/niantic-labs/spz.git
+cd spz
+
+# Install in development mode
+pip install -e .
+
+# Or install development dependencies
+pip install -r requirements-dev.txt
+pip install -e .
+```
+
+#### Examples
+
+```bash
+# Basic conversion example
+python python/examples/example.py input.ply output.spz
+
+# Bidirectional conversion with integrity checking
+python python/examples/example_bidirectional.py input.ply
+```
+
+#### Testing
+
+Run the comprehensive test suite:
+
+```bash
+# Run all tests
+pytest python/tests/
+
+# Run specific test categories
+pytest python/tests/test_ply_to_spz.py      # PLY to SPZ conversion tests
+pytest python/tests/test_spz_to_ply.py      # SPZ to PLY conversion tests
+pytest python/tests/test_roundtrip.py       # Roundtrip integrity tests
+```
+
 ### C++
 
 Requires `libz` as the only dependent library, otherwise the code is completely self-contained.

--- a/build.py
+++ b/build.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+Build script for creating SPZ Python distributions.
+"""
+
+import subprocess
+import sys
+import os
+
+def run_command(cmd):
+    """Run a command and check for errors."""
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error: {result.stderr}")
+        sys.exit(1)
+    return result.stdout
+
+def main():
+    """Build the package."""
+    # Clean previous builds
+    if os.path.exists("dist"):
+        import shutil
+        shutil.rmtree("dist")
+    
+    if os.path.exists("build"):
+        import shutil
+        shutil.rmtree("build")
+    
+    # Build source distribution
+    run_command([sys.executable, "-m", "build", "--sdist"])
+    
+    # Build wheel
+    run_command([sys.executable, "-m", "build", "--wheel"])
+    
+    print("Build completed successfully!")
+    print("Distribution files created in dist/")
+
+if __name__ == "__main__":
+    main() 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+requires = ["pybind11>=2.6.0", "setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "spz"
+version = "1.1.0"
+description = "Python bindings for SPZ compressed 3D gaussian splats"
+readme = "README.md"
+license = {file = "LICENSE"}
+authors = [
+    {name = "Niantic"},
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering",
+]
+requires-python = ">=3.7"
+dependencies = [
+    "numpy>=1.19.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=6.0",
+    "black",
+    "isort",
+    "mypy",
+]
+
+[tool.black]
+line-length = 88
+target-version = ["py37"]
+
+[tool.isort]
+profile = "black" 

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,109 @@
+# SPZ Python Package
+
+This directory contains the Python components of the SPZ (compressed Gaussian splat) format library.
+
+## Directory Structure
+
+```
+python/
+├── spz/                    # Main Python package
+│   ├── __init__.py        # Package initialization and public API
+│   ├── core.py           # Core Python utilities
+│   ├── _core.cpython-*.so # Compiled C++ extension
+│   └── bindings/         # C++ binding source code
+│       └── spz_bindings.cpp
+├── examples/             # Example scripts
+│   ├── README.md        # Examples documentation
+│   ├── example.py       # Basic PLY to SPZ conversion
+│   └── example_bidirectional.py # Advanced bidirectional conversion
+└── tests/               # Test suites
+    ├── README.md       # Test documentation
+    ├── conftest.py     # Shared test utilities
+    ├── test_import.py  # Import functionality tests
+    ├── test_ply_to_spz.py   # PLY to SPZ conversion tests
+    ├── test_spz_to_ply.py   # SPZ to PLY conversion tests
+    └── test_roundtrip.py    # Roundtrip conversion tests
+```
+
+## Package Components
+
+### Main Package (`spz/`)
+- **Core module**: Provides the main Python API for SPZ format conversion
+- **Bindings**: C++ extension providing high-performance conversion routines
+- **Public API**: 
+  - `spz.ply_to_spz()` - Convert PLY files to compressed SPZ format
+  - `spz.spz_to_ply()` - Convert SPZ files back to PLY format
+
+### Examples (`examples/`)
+Ready-to-run example scripts demonstrating:
+- Basic file conversion
+- Bidirectional conversion workflows
+- Performance measurement
+- Error handling
+
+### Tests (`tests/`)
+Comprehensive test suite covering:
+- Module imports and API availability
+- Conversion functionality for both directions
+- Roundtrip data integrity
+- Error handling and edge cases
+- Multiple coordinate system support
+
+## Installation
+
+From the project root:
+
+```bash
+# Install in development mode
+pip install -e .
+
+# Or install from wheel
+pip install .
+```
+
+## Quick Start
+
+```python
+import spz
+
+# Convert PLY to SPZ
+success = spz.ply_to_spz("input.ply", "output.spz", coordinate_system="RDF")
+
+# Convert SPZ back to PLY
+success = spz.spz_to_ply("input.spz", "output.ply", coordinate_system="RDF")
+```
+
+## Coordinate Systems
+
+Supported coordinate systems:
+- **RDF**: Right-Down-Forward (typical for PLY files)
+- **RUB**: Right-Up-Back
+- **LUF**: Left-Up-Forward  
+- **RUF**: Right-Up-Forward
+- **UNSPECIFIED**: Use default handling
+
+## Development
+
+### Building
+The C++ extension is built automatically during installation using pybind11.
+
+### Testing
+```bash
+# Run all tests
+pytest python/tests/
+
+# Run with coverage
+pytest python/tests/ --cov=spz
+
+# Run specific test categories
+pytest python/tests/test_ply_to_spz.py
+```
+
+### Examples
+```bash
+# Basic conversion
+python python/examples/example.py samples/splat.ply output.spz
+
+# Advanced features
+python python/examples/example_bidirectional.py samples/splat.ply output/
+``` 

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -1,0 +1,57 @@
+# SPZ Python Examples
+
+This directory contains example scripts demonstrating how to use the SPZ Python bindings.
+
+## Examples
+
+### `example.py`
+Basic example showing how to convert a PLY file to SPZ format.
+
+**Usage:**
+```bash
+python example.py <input.ply> <output.spz>
+```
+
+**Features:**
+- Converts PLY to SPZ using RDF coordinate system
+- Shows compression statistics
+- Error handling for missing files
+
+### `example_bidirectional.py`
+Advanced example demonstrating bidirectional conversion between PLY and SPZ formats.
+
+**Usage:**
+```bash
+python example_bidirectional.py <input.ply> <output_directory>
+```
+
+**Features:**
+- PLY → SPZ → PLY roundtrip conversion
+- Multiple coordinate system support
+- Detailed compression analysis
+- Performance timing
+- Quality verification
+
+## Running Examples
+
+Make sure you have the SPZ package installed:
+
+```bash
+pip install -e .
+```
+
+Then you can run the examples from the project root:
+
+```bash
+# Basic conversion
+python python/examples/example.py samples/splat.ply output.spz
+
+# Bidirectional conversion
+python python/examples/example_bidirectional.py samples/splat.ply output/
+```
+
+## Requirements
+
+- Python 3.7+
+- SPZ Python bindings
+- Sample PLY files (available in the `samples/` directory) 

--- a/python/examples/example.py
+++ b/python/examples/example.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+Example usage of the SPZ Python bindings.
+
+This example shows how to convert a PLY file to SPZ format.
+"""
+
+import sys
+import os
+import spz
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: python example.py <input.ply> <output.spz>")
+        sys.exit(1)
+    
+    ply_path = sys.argv[1]
+    spz_path = sys.argv[2]
+    
+    if not os.path.exists(ply_path):
+        print(f"Error: Input file {ply_path} does not exist")
+        sys.exit(1)
+    
+    print(f"Converting {ply_path} to {spz_path}...")
+    
+    # Convert PLY to SPZ using RDF coordinate system (typical for PLY files)
+    success = spz.ply_to_spz(ply_path, spz_path, coordinate_system="RDF")
+    
+    if success:
+        print("Conversion successful!")
+        
+        # Check file sizes
+        ply_size = os.path.getsize(ply_path)
+        spz_size = os.path.getsize(spz_path)
+        compression_ratio = ply_size / spz_size if spz_size > 0 else float('inf')
+        
+        print(f"PLY file size: {ply_size:,} bytes")
+        print(f"SPZ file size: {spz_size:,} bytes")
+        print(f"Compression ratio: {compression_ratio:.2f}x")
+    else:
+        print("Conversion failed!")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main() 

--- a/python/examples/example_bidirectional.py
+++ b/python/examples/example_bidirectional.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Example script demonstrating bidirectional conversion between PLY and SPZ formats.
+
+This script shows how to:
+1. Convert PLY to SPZ (compression)
+2. Convert SPZ back to PLY (decompression) 
+3. Handle different coordinate systems
+4. Check compression ratios and file integrity
+
+Usage:
+    python example_bidirectional.py [ply_file]
+
+If no PLY file is provided, it will look for samples/splat.ply
+"""
+
+import os
+import sys
+import tempfile
+import time
+import spz
+
+
+def format_bytes(size):
+    """Format byte size into human readable format."""
+    for unit in ['B', 'KB', 'MB', 'GB']:
+        if size < 1024.0:
+            return f"{size:.1f} {unit}"
+        size /= 1024.0
+    return f"{size:.1f} TB"
+
+
+def main():
+    # Determine input PLY file
+    if len(sys.argv) > 1:
+        ply_file = sys.argv[1]
+    else:
+        # Look for the sample file
+        ply_file = "samples/splat.ply"
+    
+    if not os.path.exists(ply_file):
+        print(f"❌ PLY file not found: {ply_file}")
+        print("Usage: python example_bidirectional.py [ply_file]")
+        sys.exit(1)
+    
+    print(f"🎯 SPZ Bidirectional Conversion Example")
+    print(f"📁 Input PLY file: {ply_file}")
+    print(f"📊 Input file size: {format_bytes(os.path.getsize(ply_file))}")
+    print()
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        spz_file = os.path.join(tmpdir, "compressed.spz")
+        output_ply_file = os.path.join(tmpdir, "decompressed.ply")
+        
+        # Step 1: PLY to SPZ conversion (compression)
+        print("🔄 Step 1: Compressing PLY to SPZ...")
+        start_time = time.time()
+        
+        success = spz.ply_to_spz(ply_file, spz_file, coordinate_system="RDF")
+        
+        compression_time = time.time() - start_time
+        
+        if not success:
+            print("❌ PLY to SPZ conversion failed!")
+            sys.exit(1)
+        
+        spz_size = os.path.getsize(spz_file)
+        ply_size = os.path.getsize(ply_file)
+        compression_ratio = ply_size / spz_size
+        
+        print(f"✅ Compression successful!")
+        print(f"   📊 SPZ file size: {format_bytes(spz_size)}")
+        print(f"   🚀 Compression ratio: {compression_ratio:.2f}x")
+        print(f"   ⏱️  Time taken: {compression_time:.2f} seconds")
+        print()
+        
+        # Step 2: SPZ to PLY conversion (decompression)
+        print("🔄 Step 2: Decompressing SPZ to PLY...")
+        start_time = time.time()
+        
+        success = spz.spz_to_ply(spz_file, output_ply_file, coordinate_system="RDF")
+        
+        decompression_time = time.time() - start_time
+        
+        if not success:
+            print("❌ SPZ to PLY conversion failed!")
+            sys.exit(1)
+        
+        output_size = os.path.getsize(output_ply_file)
+        
+        print(f"✅ Decompression successful!")
+        print(f"   📊 Output PLY size: {format_bytes(output_size)}")
+        print(f"   ⏱️  Time taken: {decompression_time:.2f} seconds")
+        print()
+        
+        # Step 3: Integrity check
+        print("🔍 Step 3: Integrity Check...")
+        size_difference = abs(output_size - ply_size)
+        size_ratio = output_size / ply_size
+        
+        print(f"   📊 Original PLY: {format_bytes(ply_size)}")
+        print(f"   📊 Roundtrip PLY: {format_bytes(output_size)}")
+        print(f"   📊 Size difference: {format_bytes(size_difference)}")
+        print(f"   📊 Size ratio: {size_ratio:.4f}")
+        
+        if 0.99 <= size_ratio <= 1.01:
+            print("   ✅ File sizes match closely - good integrity!")
+        elif 0.95 <= size_ratio <= 1.05:
+            print("   ⚠️  Minor size difference (likely due to precision)")
+        else:
+            print("   ❌ Significant size difference detected")
+        print()
+        
+        # Step 4: Test different coordinate systems
+        print("🌐 Step 4: Testing Different Coordinate Systems...")
+        coordinate_systems = ["RDF", "RUB", "LUF", "RUF", "UNSPECIFIED"]
+        
+        for i, cs in enumerate(coordinate_systems, 1):
+            cs_spz_file = os.path.join(tmpdir, f"test_{cs}.spz")
+            cs_ply_file = os.path.join(tmpdir, f"test_{cs}.ply")
+            
+            # Convert with specific coordinate system
+            success1 = spz.ply_to_spz(ply_file, cs_spz_file, coordinate_system=cs)
+            success2 = spz.spz_to_ply(cs_spz_file, cs_ply_file, coordinate_system=cs)
+            
+            if success1 and success2:
+                cs_compression = ply_size / os.path.getsize(cs_spz_file)
+                print(f"   {i}. {cs:12} ✅ Compression: {cs_compression:.2f}x")
+            else:
+                print(f"   {i}. {cs:12} ❌ Failed")
+        
+        print()
+        
+        # Summary
+        print("📈 Summary:")
+        print(f"   🏆 Best compression ratio: {compression_ratio:.2f}x")
+        print(f"   💾 Space saved: {format_bytes(ply_size - spz_size)} ({((ply_size - spz_size) / ply_size * 100):.1f}%)")
+        print(f"   ⚡ Total processing time: {compression_time + decompression_time:.2f} seconds")
+        print()
+        print("🎉 Bidirectional conversion completed successfully!")
+        print("   The SPZ format provides excellent compression while maintaining data integrity.")
+
+
+if __name__ == "__main__":
+    main() 

--- a/python/spz/__init__.py
+++ b/python/spz/__init__.py
@@ -1,0 +1,11 @@
+"""
+SPZ: Python bindings for compressed 3D Gaussian splats
+
+This package provides Python bindings for loading, converting, and saving
+SPZ files, which are a compressed format for 3D Gaussian splats.
+"""
+
+from .core import ply_to_spz, spz_to_ply
+
+__version__ = "1.1.0"
+__all__ = ["ply_to_spz", "spz_to_ply"] 

--- a/python/spz/bindings/spz_bindings.cpp
+++ b/python/spz/bindings/spz_bindings.cpp
@@ -1,0 +1,104 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+#include <string>
+#include <stdexcept>
+
+#include "load-spz.h"
+#include "splat-types.h"
+
+namespace py = pybind11;
+
+// Helper function to convert string to CoordinateSystem enum
+spz::CoordinateSystem stringToCoordinateSystem(const std::string& cs) {
+    if (cs == "UNSPECIFIED") return spz::CoordinateSystem::UNSPECIFIED;
+    if (cs == "LDB") return spz::CoordinateSystem::LDB;
+    if (cs == "RDB") return spz::CoordinateSystem::RDB;
+    if (cs == "LUB") return spz::CoordinateSystem::LUB;
+    if (cs == "RUB") return spz::CoordinateSystem::RUB;
+    if (cs == "LDF") return spz::CoordinateSystem::LDF;
+    if (cs == "RDF") return spz::CoordinateSystem::RDF;
+    if (cs == "LUF") return spz::CoordinateSystem::LUF;
+    if (cs == "RUF") return spz::CoordinateSystem::RUF;
+    throw std::invalid_argument("Invalid coordinate system: " + cs);
+}
+
+// PLY to SPZ conversion function
+bool ply_to_spz_impl(const std::string& ply_path, const std::string& spz_path, const std::string& coordinate_system) {
+    // Validate coordinate system first (let invalid_argument exceptions propagate)
+    spz::CoordinateSystem coord_sys = stringToCoordinateSystem(coordinate_system);
+    
+    try {
+        // Set up unpacking options (for loading PLY)
+        spz::UnpackOptions unpack_options;
+        unpack_options.to = coord_sys;
+        
+        // Load the PLY file
+        spz::GaussianCloud gaussians = spz::loadSplatFromPly(ply_path, unpack_options);
+        
+        if (gaussians.numPoints == 0) {
+            return false;  // Failed to load PLY file
+        }
+        
+        // Set up packing options (for saving SPZ)
+        spz::PackOptions pack_options;
+        pack_options.from = coord_sys;
+        
+        // Save as SPZ
+        bool success = spz::saveSpz(gaussians, pack_options, spz_path);
+        
+        return success;
+    } catch (const std::invalid_argument& e) {
+        // Re-throw coordinate system errors
+        throw;
+    } catch (const std::exception& e) {
+        // Other errors return false
+        return false;
+    }
+}
+
+// SPZ to PLY conversion function
+bool spz_to_ply_impl(const std::string& spz_path, const std::string& ply_path, const std::string& coordinate_system) {
+    // Validate coordinate system first (let invalid_argument exceptions propagate)
+    spz::CoordinateSystem coord_sys = stringToCoordinateSystem(coordinate_system);
+    
+    try {
+        // Set up unpacking options (for loading SPZ)
+        spz::UnpackOptions unpack_options;
+        unpack_options.to = coord_sys;
+        
+        // Load the SPZ file
+        spz::GaussianCloud gaussians = spz::loadSpz(spz_path, unpack_options);
+        
+        if (gaussians.numPoints == 0) {
+            return false;  // Failed to load SPZ file
+        }
+        
+        // Set up packing options (for saving PLY)
+        spz::PackOptions pack_options;
+        pack_options.from = coord_sys;
+        
+        // Save as PLY
+        bool success = spz::saveSplatToPly(gaussians, pack_options, ply_path);
+        
+        return success;
+    } catch (const std::invalid_argument& e) {
+        // Re-throw coordinate system errors
+        throw;
+    } catch (const std::exception& e) {
+        // Other errors return false
+        return false;
+    }
+}
+
+PYBIND11_MODULE(_core, m) {
+    m.doc() = "SPZ Python bindings for compressed 3D Gaussian splats";
+    
+    m.def("_ply_to_spz_impl", &ply_to_spz_impl, 
+          "Convert PLY file to SPZ format",
+          py::arg("ply_path"), py::arg("spz_path"), py::arg("coordinate_system"));
+    
+    m.def("_spz_to_ply_impl", &spz_to_ply_impl,
+          "Convert SPZ file to PLY format", 
+          py::arg("spz_path"), py::arg("ply_path"), py::arg("coordinate_system"));
+} 

--- a/python/spz/core.py
+++ b/python/spz/core.py
@@ -1,0 +1,66 @@
+"""
+Core Python interface for SPZ operations.
+"""
+
+from typing import Optional
+from ._core import _ply_to_spz_impl, _spz_to_ply_impl
+
+
+def ply_to_spz(
+    ply_path: str,
+    spz_path: str,
+    coordinate_system: str = "RDF"
+) -> bool:
+    """
+    Convert a PLY file to SPZ format.
+    
+    Args:
+        ply_path: Path to the input PLY file
+        spz_path: Path to the output SPZ file
+        coordinate_system: Coordinate system of the input PLY file.
+                          Options: "RDF" (default, typical PLY format),
+                                  "RUB" (Three.js/OpenGL),
+                                  "LUF" (GLB format), 
+                                  "RUF" (Unity format),
+                                  or "UNSPECIFIED"
+    
+    Returns:
+        True if conversion was successful, False otherwise
+        
+    Example:
+        >>> import spz
+        >>> success = spz.ply_to_spz("input.ply", "output.spz")
+        >>> if success:
+        ...     print("Conversion successful!")
+    """
+    return _ply_to_spz_impl(ply_path, spz_path, coordinate_system)
+
+
+def spz_to_ply(
+    spz_path: str,
+    ply_path: str,
+    coordinate_system: str = "RDF"
+) -> bool:
+    """
+    Convert an SPZ file to PLY format.
+    
+    Args:
+        spz_path: Path to the input SPZ file
+        ply_path: Path to the output PLY file  
+        coordinate_system: Target coordinate system for the output PLY file.
+                          Options: "RDF" (default, typical PLY format),
+                                  "RUB" (Three.js/OpenGL),
+                                  "LUF" (GLB format),
+                                  "RUF" (Unity format),
+                                  or "UNSPECIFIED"
+    
+    Returns:
+        True if conversion was successful, False otherwise
+        
+    Example:
+        >>> import spz
+        >>> success = spz.spz_to_ply("input.spz", "output.ply")
+        >>> if success:
+        ...     print("Conversion successful!")
+    """
+    return _spz_to_ply_impl(spz_path, ply_path, coordinate_system) 

--- a/python/tests/README.md
+++ b/python/tests/README.md
@@ -1,0 +1,102 @@
+# SPZ Python Tests
+
+This directory contains test suites for the SPZ Python bindings, organized by functionality.
+
+## Test Files
+
+### `test_import.py`
+Tests for basic module import functionality:
+- Module import validation
+- Function availability checks
+- Version information
+
+### `test_ply_to_spz.py`
+Tests for PLY to SPZ conversion:
+- File format conversion
+- Coordinate system handling
+- Error handling with missing files
+- Compression verification
+- Multiple coordinate systems (RDF, RUB, LUF, RUF)
+
+### `test_spz_to_ply.py`
+Tests for SPZ to PLY conversion:
+- Reverse conversion functionality
+- Coordinate system support
+- Error handling
+- File validation
+
+### `test_roundtrip.py`
+Tests for roundtrip conversions (PLY → SPZ → PLY):
+- Data integrity verification
+- Compression analysis
+- Multiple coordinate systems
+- Size ratio validation
+
+### `conftest.py`
+Shared test utilities and fixtures:
+- `sample_ply_path` fixture for test data
+- `create_simple_ply()` utility for creating test PLY files
+- Common test helpers
+
+## Running Tests
+
+### All Tests
+```bash
+# From project root
+pytest python/tests/
+
+# With verbose output
+pytest python/tests/ -v
+
+# With output capture disabled (to see print statements)
+pytest python/tests/ -s
+```
+
+### Individual Test Files
+```bash
+# Test imports only
+pytest python/tests/test_import.py
+
+# Test PLY to SPZ conversion
+pytest python/tests/test_ply_to_spz.py
+
+# Test SPZ to PLY conversion
+pytest python/tests/test_spz_to_ply.py
+
+# Test roundtrip conversions
+pytest python/tests/test_roundtrip.py
+```
+
+### Specific Tests
+```bash
+# Run a specific test function
+pytest python/tests/test_ply_to_spz.py::test_ply_to_spz_simple_conversion
+
+# Run tests matching a pattern
+pytest python/tests/ -k "conversion"
+```
+
+## Test Requirements
+
+- Python 3.7+
+- pytest
+- SPZ Python bindings
+- Sample PLY files (in `samples/` directory)
+
+## Test Data
+
+Tests use:
+- Sample PLY files from the `samples/` directory
+- Dynamically created simple PLY files for basic testing
+- Temporary directories for output files (automatically cleaned up)
+
+## Coverage
+
+The tests cover:
+- ✅ Basic imports and function availability
+- ✅ PLY to SPZ conversion with various coordinate systems
+- ✅ SPZ to PLY conversion with various coordinate systems
+- ✅ Roundtrip conversion integrity
+- ✅ Error handling for invalid inputs
+- ✅ File compression verification
+- ✅ Coordinate system validation 

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPZ Python tests package 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,80 @@
+"""Shared test fixtures and utilities for SPZ tests."""
+
+import pytest
+import os
+import struct
+import tempfile
+
+
+@pytest.fixture
+def sample_ply_path():
+    """Get the path to the sample PLY file."""
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(os.path.dirname(current_dir))
+    return os.path.join(project_root, "samples", "splat.ply")
+
+
+@pytest.fixture
+def sample_spz_paths():
+    """Get paths to the sample SPZ files."""
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(os.path.dirname(current_dir))
+    samples_dir = os.path.join(project_root, "samples")
+    return {
+        "hornedlizard": os.path.join(samples_dir, "hornedlizard.spz"),
+        "racoonfamily": os.path.join(samples_dir, "racoonfamily.spz")
+    }
+
+
+def create_simple_ply(ply_path):
+    """Create a simple PLY file with correct format for testing (degree 0 SH - no extra coefficients)."""
+    # Create a minimal PLY file with 2 gaussians in degree 0 format (no spherical harmonics beyond DC)
+    header = """ply
+format binary_little_endian 1.0
+element vertex 2
+property float x
+property float y
+property float z
+property float nx
+property float ny
+property float nz
+property float f_dc_0
+property float f_dc_1
+property float f_dc_2
+property float opacity
+property float scale_0
+property float scale_1
+property float scale_2
+property float rot_0
+property float rot_1
+property float rot_2
+property float rot_3
+end_header
+"""
+    
+    # Create some simple gaussian data (2 gaussians with degree 0 SH - only DC coefficients)
+    gaussian1 = [
+        0.0, 0.0, 0.0,  # position (x, y, z)
+        0.0, 0.0, 1.0,  # normal (nx, ny, nz) - not really used
+        0.5, 0.3, 0.2,  # color DC (f_dc_0, f_dc_1, f_dc_2)
+        1.0,            # opacity
+        0.1, 0.1, 0.1,  # scale (scale_0, scale_1, scale_2)
+        1.0, 0.0, 0.0, 0.0  # rotation quaternion (rot_0, rot_1, rot_2, rot_3)
+    ]
+    
+    gaussian2 = [
+        1.0, 1.0, 1.0,  # position (x, y, z)
+        0.0, 0.0, 1.0,  # normal (nx, ny, nz)
+        0.8, 0.1, 0.1,  # color DC (f_dc_0, f_dc_1, f_dc_2)
+        0.8,            # opacity
+        0.2, 0.15, 0.1, # scale (scale_0, scale_1, scale_2)
+        0.707, 0.707, 0.0, 0.0  # rotation quaternion (rot_0, rot_1, rot_2, rot_3)
+    ]
+    
+    with open(ply_path, 'wb') as f:
+        f.write(header.encode('ascii'))
+        
+        # Write binary data for both gaussians
+        for gaussian in [gaussian1, gaussian2]:
+            for value in gaussian:
+                f.write(struct.pack('<f', value))  # little-endian float 

--- a/python/tests/test_import.py
+++ b/python/tests/test_import.py
@@ -1,0 +1,23 @@
+"""Tests for basic SPZ module import functionality."""
+
+import pytest
+import spz
+
+
+def test_import():
+    """Test that the module can be imported and has expected attributes."""
+    assert hasattr(spz, 'ply_to_spz')
+    assert hasattr(spz, 'spz_to_ply')
+    assert hasattr(spz, '__version__')
+
+
+def test_import_ply_to_spz():
+    """Test that the ply_to_spz function is available."""
+    assert hasattr(spz, 'ply_to_spz')
+    assert callable(spz.ply_to_spz)
+
+
+def test_import_spz_to_ply():
+    """Test that the spz_to_ply function is available."""
+    assert hasattr(spz, 'spz_to_ply')
+    assert callable(spz.spz_to_ply) 

--- a/python/tests/test_ply_to_spz.py
+++ b/python/tests/test_ply_to_spz.py
@@ -1,0 +1,130 @@
+"""Tests for PLY to SPZ conversion functionality."""
+
+import pytest
+import os
+import tempfile
+import spz
+from .conftest import create_simple_ply
+
+
+def test_ply_to_spz_missing_file():
+    """Test that conversion fails gracefully with missing input file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ply_path = os.path.join(tmpdir, "nonexistent.ply")
+        spz_path = os.path.join(tmpdir, "output.spz")
+        
+        result = spz.ply_to_spz(ply_path, spz_path)
+        assert result is False
+
+
+def test_coordinate_systems_nonexistent_file():
+    """Test that different coordinate systems are accepted without error."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ply_path = os.path.join(tmpdir, "nonexistent.ply")
+        spz_path = os.path.join(tmpdir, "output.spz")
+        
+        # These should all fail gracefully (return False) but not raise exceptions
+        coordinate_systems = ["RDF", "RUB", "LUF", "RUF", "UNSPECIFIED"]
+        
+        for cs in coordinate_systems:
+            result = spz.ply_to_spz(ply_path, spz_path, coordinate_system=cs)
+            assert result is False  # Should fail because file doesn't exist
+
+
+def test_invalid_coordinate_system():
+    """Test that invalid coordinate systems raise appropriate errors."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ply_path = os.path.join(tmpdir, "nonexistent.ply")
+        spz_path = os.path.join(tmpdir, "output.spz")
+        
+        with pytest.raises(Exception):  # Should raise an exception for invalid CS
+            spz.ply_to_spz(ply_path, spz_path, coordinate_system="INVALID")
+
+
+def test_ply_to_spz_simple_conversion():
+    """Test PLY to SPZ conversion with a simple compatible PLY file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ply_path = os.path.join(tmpdir, "simple.ply")
+        spz_path = os.path.join(tmpdir, "simple.spz")
+        
+        # Create a simple PLY file in the correct format
+        create_simple_ply(ply_path)
+        
+        # Test conversion
+        result = spz.ply_to_spz(ply_path, spz_path, coordinate_system="RDF")
+        
+        # Verify conversion succeeded
+        assert result is True, "Simple PLY to SPZ conversion should succeed"
+        
+        # Verify output file was created
+        assert os.path.exists(spz_path), "SPZ output file should be created"
+        
+        # Verify output file has content
+        spz_size = os.path.getsize(spz_path)
+        assert spz_size > 0, "SPZ file should not be empty"
+        
+        # Verify compression
+        ply_size = os.path.getsize(ply_path)
+        
+        print(f"Simple conversion test passed:")
+        print(f"  PLY size: {ply_size:,} bytes")
+        print(f"  SPZ size: {spz_size:,} bytes")
+
+
+def test_ply_to_spz_actual_conversion(sample_ply_path):
+    """Test actual PLY to SPZ conversion using the sample file."""
+    # Skip test if sample file doesn't exist
+    if not os.path.exists(sample_ply_path):
+        pytest.skip("Sample PLY file not found")
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        spz_path = os.path.join(tmpdir, "output.spz")
+        
+        # Test conversion with default coordinate system (RDF)
+        result = spz.ply_to_spz(sample_ply_path, spz_path, coordinate_system="RDF")
+        
+        # The PLY file should now have the correct float format and conversion should succeed
+        assert result is True, "PLY to SPZ conversion should succeed with corrected float format"
+        
+        # Verify output file was created
+        assert os.path.exists(spz_path), "SPZ output file should be created"
+        
+        # Verify output file has content
+        spz_size = os.path.getsize(spz_path)
+        assert spz_size > 0, "SPZ file should not be empty"
+        
+        # Verify compression
+        ply_size = os.path.getsize(sample_ply_path)
+        compression_ratio = ply_size / spz_size
+        
+        print(f"Actual PLY conversion test passed:")
+        print(f"  PLY size: {ply_size:,} bytes")
+        print(f"  SPZ size: {spz_size:,} bytes") 
+        print(f"  Compression ratio: {compression_ratio:.2f}x")
+        
+        # SPZ should be significantly smaller than PLY
+        assert compression_ratio > 1.0, "SPZ file should be smaller than PLY file"
+
+
+def test_ply_to_spz_different_coordinate_systems(sample_ply_path):
+    """Test PLY to SPZ conversion with different coordinate systems."""
+    # Skip test if sample file doesn't exist
+    if not os.path.exists(sample_ply_path):
+        pytest.skip("Sample PLY file not found")
+    
+    coordinate_systems = ["RDF", "RUB", "LUF", "RUF"]
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for cs in coordinate_systems:
+            spz_path = os.path.join(tmpdir, f"output_{cs}.spz")
+            
+            # Test conversion with each coordinate system
+            result = spz.ply_to_spz(sample_ply_path, spz_path, coordinate_system=cs)
+            
+            # With the corrected PLY format, conversion should succeed for all coordinate systems
+            assert result is True, f"PLY to SPZ conversion should succeed with {cs} coordinate system"
+            
+            # Verify the output
+            assert os.path.exists(spz_path), f"SPZ file with {cs} coordinate system should be created"
+            assert os.path.getsize(spz_path) > 0, f"SPZ file with {cs} coordinate system should not be empty"
+            print(f"Conversion with {cs} coordinate system succeeded") 

--- a/python/tests/test_roundtrip.py
+++ b/python/tests/test_roundtrip.py
@@ -1,0 +1,112 @@
+"""Tests for roundtrip conversion functionality (PLY -> SPZ -> PLY)."""
+
+import pytest
+import os
+import tempfile
+import spz
+from .conftest import create_simple_ply
+
+
+def test_spz_to_ply_roundtrip(sample_ply_path):
+    """Test roundtrip conversion: PLY -> SPZ -> PLY."""
+    # Skip test if sample file doesn't exist
+    if not os.path.exists(sample_ply_path):
+        pytest.skip("Sample PLY file not found")
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        spz_path = os.path.join(tmpdir, "intermediate.spz")
+        output_ply_path = os.path.join(tmpdir, "roundtrip.ply")
+        
+        # PLY -> SPZ -> PLY roundtrip
+        result1 = spz.ply_to_spz(sample_ply_path, spz_path, coordinate_system="RDF")
+        assert result1, "PLY to SPZ conversion should succeed"
+        
+        result2 = spz.spz_to_ply(spz_path, output_ply_path, coordinate_system="RDF")
+        assert result2, "SPZ to PLY conversion should succeed"
+        
+        # Both files should exist and be non-empty
+        assert os.path.exists(spz_path), "SPZ file should exist"
+        assert os.path.exists(output_ply_path), "Output PLY file should exist"
+        assert os.path.getsize(spz_path) > 0, "SPZ file should not be empty"
+        assert os.path.getsize(output_ply_path) > 0, "Output PLY file should not be empty"
+        
+        # Check file sizes
+        original_size = os.path.getsize(sample_ply_path)
+        spz_size = os.path.getsize(spz_path)
+        output_size = os.path.getsize(output_ply_path)
+        
+        print(f"Roundtrip test:")
+        print(f"  Original PLY: {original_size:,} bytes")
+        print(f"  SPZ: {spz_size:,} bytes")
+        print(f"  Roundtrip PLY: {output_size:,} bytes")
+        print(f"  Compression ratio: {original_size/spz_size:.2f}x")
+        
+        # Output PLY might be slightly different size due to precision changes,
+        # but should be in the same ballpark
+        size_ratio = output_size / original_size
+        assert 0.8 <= size_ratio <= 1.2, f"Roundtrip PLY size should be similar to original (ratio: {size_ratio:.2f})"
+
+
+def test_simple_roundtrip():
+    """Test roundtrip with a simple created PLY file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        original_ply_path = os.path.join(tmpdir, "original.ply")
+        spz_path = os.path.join(tmpdir, "intermediate.spz")
+        roundtrip_ply_path = os.path.join(tmpdir, "roundtrip.ply")
+        
+        # Create original PLY file
+        create_simple_ply(original_ply_path)
+        
+        # Roundtrip conversion
+        result1 = spz.ply_to_spz(original_ply_path, spz_path, coordinate_system="RDF")
+        assert result1, "PLY to SPZ conversion should succeed"
+        
+        result2 = spz.spz_to_ply(spz_path, roundtrip_ply_path, coordinate_system="RDF")
+        assert result2, "SPZ to PLY conversion should succeed"
+        
+        # Verify all files exist and have content
+        assert os.path.exists(spz_path), "SPZ file should exist"
+        assert os.path.exists(roundtrip_ply_path), "Roundtrip PLY file should exist"
+        assert os.path.getsize(spz_path) > 0, "SPZ file should not be empty"
+        assert os.path.getsize(roundtrip_ply_path) > 0, "Roundtrip PLY file should not be empty"
+        
+        # Check compression
+        original_size = os.path.getsize(original_ply_path)
+        spz_size = os.path.getsize(spz_path)
+        roundtrip_size = os.path.getsize(roundtrip_ply_path)
+        
+        print(f"Simple roundtrip test:")
+        print(f"  Original PLY: {original_size:,} bytes")
+        print(f"  SPZ: {spz_size:,} bytes")
+        print(f"  Roundtrip PLY: {roundtrip_size:,} bytes")
+        print(f"  Compression ratio: {original_size/spz_size:.2f}x")
+        
+        assert spz_size < original_size, "SPZ should be smaller than original PLY"
+
+
+def test_roundtrip_different_coordinate_systems(sample_ply_path):
+    """Test roundtrip conversions with different coordinate systems."""
+    if not os.path.exists(sample_ply_path):
+        pytest.skip("Sample PLY file not found")
+    
+    coordinate_systems = ["RDF", "RUB", "LUF", "RUF"]
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for cs in coordinate_systems:
+            spz_path = os.path.join(tmpdir, f"intermediate_{cs}.spz")
+            output_ply_path = os.path.join(tmpdir, f"roundtrip_{cs}.ply")
+            
+            # Roundtrip with specific coordinate system
+            result1 = spz.ply_to_spz(sample_ply_path, spz_path, coordinate_system=cs)
+            assert result1, f"PLY to SPZ conversion with {cs} should succeed"
+            
+            result2 = spz.spz_to_ply(spz_path, output_ply_path, coordinate_system=cs)
+            assert result2, f"SPZ to PLY conversion with {cs} should succeed"
+            
+            # Verify files
+            assert os.path.exists(spz_path), f"SPZ file with {cs} should exist"
+            assert os.path.exists(output_ply_path), f"Output PLY file with {cs} should exist"
+            assert os.path.getsize(spz_path) > 0, f"SPZ file with {cs} should not be empty"
+            assert os.path.getsize(output_ply_path) > 0, f"Output PLY file with {cs} should not be empty"
+            
+            print(f"Roundtrip with {cs} coordinate system succeeded") 

--- a/python/tests/test_spz_to_ply.py
+++ b/python/tests/test_spz_to_ply.py
@@ -1,0 +1,153 @@
+"""Tests for SPZ to PLY conversion functionality."""
+
+import pytest
+import os
+import tempfile
+import spz
+from .conftest import create_simple_ply
+
+
+def test_spz_to_ply_basic(sample_ply_path):
+    """Test basic SPZ to PLY conversion functionality."""
+    # Skip test if sample file doesn't exist
+    if not os.path.exists(sample_ply_path):
+        pytest.skip("Sample PLY file not found")
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        spz_path = os.path.join(tmpdir, "intermediate.spz")
+        output_ply_path = os.path.join(tmpdir, "output.ply")
+        
+        # First convert PLY to SPZ
+        result1 = spz.ply_to_spz(sample_ply_path, spz_path, coordinate_system="RDF")
+        assert result1, "PLY to SPZ conversion should succeed"
+        assert os.path.exists(spz_path), "SPZ file should be created"
+        
+        # Then convert SPZ back to PLY
+        result2 = spz.spz_to_ply(spz_path, output_ply_path, coordinate_system="RDF")
+        assert result2, "SPZ to PLY conversion should succeed"
+        assert os.path.exists(output_ply_path), "Output PLY file should be created"
+        assert os.path.getsize(output_ply_path) > 0, "Output PLY file should not be empty"
+        
+        # Check that we achieved compression in the intermediate SPZ file
+        original_size = os.path.getsize(sample_ply_path)
+        spz_size = os.path.getsize(spz_path)
+        output_size = os.path.getsize(output_ply_path)
+        
+        compression_ratio = original_size / spz_size
+        print(f"Original PLY: {original_size:,} bytes")
+        print(f"SPZ: {spz_size:,} bytes")
+        print(f"Output PLY: {output_size:,} bytes")
+        print(f"Compression ratio (original/SPZ): {compression_ratio:.2f}x")
+        
+        # SPZ should be significantly smaller than PLY
+        assert compression_ratio > 5, "SPZ should provide significant compression"
+
+
+def test_spz_to_ply_different_coordinate_systems(sample_ply_path):
+    """Test SPZ to PLY conversion with different coordinate systems."""
+    # Skip test if sample file doesn't exist
+    if not os.path.exists(sample_ply_path):
+        pytest.skip("Sample PLY file not found")
+    
+    coordinate_systems = ["RDF", "RUB", "LUF", "RUF", "UNSPECIFIED"]
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # First create an SPZ file to work with
+        spz_path = os.path.join(tmpdir, "test.spz")
+        result = spz.ply_to_spz(sample_ply_path, spz_path, coordinate_system="RDF")
+        assert result, "PLY to SPZ conversion should succeed"
+        
+        # Test conversion to PLY with each coordinate system
+        for cs in coordinate_systems:
+            output_ply_path = os.path.join(tmpdir, f"output_{cs}.ply")
+            
+            result = spz.spz_to_ply(spz_path, output_ply_path, coordinate_system=cs)
+            assert result, f"SPZ to PLY conversion with {cs} coordinate system should succeed"
+            assert os.path.exists(output_ply_path), f"PLY file with {cs} coordinate system should be created"
+            assert os.path.getsize(output_ply_path) > 0, f"PLY file with {cs} coordinate system should not be empty"
+            print(f"SPZ to PLY conversion with {cs} succeeded")
+
+
+def test_spz_to_ply_error_handling(sample_ply_path):
+    """Test error handling for spz_to_ply function."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        nonexistent_spz = os.path.join(tmpdir, "nonexistent.spz")
+        output_ply = os.path.join(tmpdir, "output.ply")
+        
+        # Test with nonexistent SPZ file
+        result = spz.spz_to_ply(nonexistent_spz, output_ply)
+        assert not result, "Should return False for nonexistent SPZ file"
+        
+        # Test with invalid coordinate system
+        if os.path.exists(sample_ply_path):
+            valid_spz = os.path.join(tmpdir, "valid.spz")
+            spz.ply_to_spz(sample_ply_path, valid_spz)
+            
+            with pytest.raises(ValueError, match="Invalid coordinate system"):
+                spz.spz_to_ply(valid_spz, output_ply, coordinate_system="INVALID")
+
+
+def test_spz_to_ply_simple_conversion():
+    """Test SPZ to PLY conversion with a simple created PLY file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ply_path = os.path.join(tmpdir, "simple.ply")
+        spz_path = os.path.join(tmpdir, "simple.spz")
+        output_ply_path = os.path.join(tmpdir, "output.ply")
+        
+        # Create a simple PLY file
+        create_simple_ply(ply_path)
+        
+        # Convert PLY to SPZ
+        result1 = spz.ply_to_spz(ply_path, spz_path, coordinate_system="RDF")
+        assert result1, "PLY to SPZ conversion should succeed"
+        
+        # Convert SPZ back to PLY
+        result2 = spz.spz_to_ply(spz_path, output_ply_path, coordinate_system="RDF")
+        assert result2, "SPZ to PLY conversion should succeed"
+        
+        # Check files exist and have content
+        assert os.path.exists(output_ply_path), "Output PLY file should be created"
+        assert os.path.getsize(output_ply_path) > 0, "Output PLY file should not be empty"
+        
+        # Check compression was achieved
+        ply_size = os.path.getsize(ply_path)
+        spz_size = os.path.getsize(spz_path)
+        output_size = os.path.getsize(output_ply_path)
+        
+        print(f"Simple SPZ to PLY conversion test:")
+        print(f"  Original PLY: {ply_size:,} bytes")
+        print(f"  SPZ: {spz_size:,} bytes")
+        print(f"  Output PLY: {output_size:,} bytes")
+        print(f"  Compression ratio: {ply_size/spz_size:.2f}x")
+        
+        assert spz_size < ply_size, "SPZ should be smaller than original PLY"
+
+
+def test_spz_to_ply_real_samples(sample_spz_paths):
+    """Test SPZ to PLY conversion using real SPZ sample files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for sample_name, spz_path in sample_spz_paths.items():
+            if not os.path.exists(spz_path):
+                pytest.skip(f"Sample SPZ file {sample_name} not found")
+                continue
+            
+            output_ply_path = os.path.join(tmpdir, f"{sample_name}_converted.ply")
+            
+            # Convert SPZ to PLY
+            result = spz.spz_to_ply(spz_path, output_ply_path, coordinate_system="RDF")
+            assert result, f"SPZ to PLY conversion should succeed for {sample_name}"
+            
+            # Verify output
+            assert os.path.exists(output_ply_path), f"Output PLY file should be created for {sample_name}"
+            assert os.path.getsize(output_ply_path) > 0, f"Output PLY file should not be empty for {sample_name}"
+            
+            # Check file sizes
+            spz_size = os.path.getsize(spz_path)
+            ply_size = os.path.getsize(output_ply_path)
+            
+            print(f"Real sample {sample_name} conversion:")
+            print(f"  SPZ size: {spz_size:,} bytes ({spz_size/1024/1024:.1f} MB)")
+            print(f"  PLY size: {ply_size:,} bytes ({ply_size/1024/1024:.1f} MB)")
+            
+            # PLY should be larger than SPZ (decompression)
+            assert ply_size > spz_size, f"Decompressed PLY should be larger than SPZ for {sample_name}" 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+pybind11>=2.6.0
+numpy>=1.19.0
+pytest>=6.0
+black
+isort
+mypy
+build
+twine 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,54 @@
+from pybind11.setup_helpers import Pybind11Extension, build_ext
+from setuptools import setup, Extension
+import pybind11
+import os
+
+# Define the extension module
+ext_modules = [
+    Pybind11Extension(
+        "spz._core",
+        [
+            "src/cc/load-spz.cc",
+            "src/cc/splat-c-types.cc", 
+            "src/cc/splat-types.cc",
+            "python/spz/bindings/spz_bindings.cpp"
+        ],
+        include_dirs=[
+            pybind11.get_cmake_dir() + "/../../../include",
+            "src/cc"
+        ],
+        libraries=["z"],  # zlib
+        cxx_std=17,
+    ),
+]
+
+setup(
+    name="spz",
+    version="1.1.0",
+    author="Niantic",
+    description="Python bindings for SPZ compressed 3D gaussian splats",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    ext_modules=ext_modules,
+    cmdclass={"build_ext": build_ext},
+    zip_safe=False,
+    python_requires=">=3.7",
+    packages=["spz"],
+    package_dir={"spz": "python/spz"},
+    install_requires=[
+        "numpy>=1.19.0",
+    ],
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Topic :: Scientific/Engineering",
+    ],
+) 

--- a/src/cc/load-spz.cc
+++ b/src/cc/load-spz.cc
@@ -605,7 +605,12 @@ GaussianCloud loadSplatFromPly(const std::string &filename, const UnpackOptions 
     in.close();
     return {};
   }
-  std::getline(in, line);
+  
+  // Skip comment lines until we find the element vertex line
+  do {
+    std::getline(in, line);
+  } while (line.find("comment ") == 0 && !in.eof());
+  
   if (line.find("element vertex ") != 0) {
     SpzLog("[SPZ ERROR] %s: missing vertex count", filename.c_str());
     in.close();

--- a/src/cc/splat-types.cc
+++ b/src/cc/splat-types.cc
@@ -67,11 +67,6 @@ Vec3f normalized(const Vec3f &v) {
   return {v[0] / n, v[1] / n, v[2] / n};
 }
 
-Quat4f normalized(const Quat4f &v) {
-  float norm = std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2] + v[3] * v[3]);
-  return {v[0] / norm, v[1] / norm, v[2] / norm, v[3] / norm};
-}
-
 float norm(const Quat4f &q) {
   return std::sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);
 }

--- a/src/cc/splat-types.h
+++ b/src/cc/splat-types.h
@@ -197,7 +197,10 @@ float norm(const Vec3f &a);
 
 // Quaternion helpers.
 float norm(const Quat4f &q);
-Quat4f normalized(const Quat4f &v);
+constexpr Quat4f normalized(const Quat4f &v) {
+  float norm = std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2] + v[3] * v[3]);
+  return {v[0] / norm, v[1] / norm, v[2] / norm, v[3] / norm};
+}
 Quat4f axisAngleQuat(const Vec3f &scaledAxis);
 
 // Constexpr helpers.


### PR DESCRIPTION
Makes the repo pip-installable and adds some (mostly Claude generated) Python bindings for `ply_to_spz` and `spz_to_ply` to start so I could use this in my existing python code that writes out plys. A test PLY file is also added.

Tested in my personal repo with a `pip install` from git and used it after some gsplat training to convert the ply to spz in the end.
```py
from spz import ply_to_spz
ply_to_spz("file.ply", "file.spz")
```

Can directly support writing from the gaussian buffers directly to SPZ without the PLY in the middle as a follow-up PR

## Notes
#30 was required for my `uv sync` that included this new python `spz` package for it to be installed correctly. There was an error with the `const expr` not being `const` that #30 fixes.