### PR TITLE
Add find_dependency(ZLIB)

### DIFF
--- a/cmake/spzConfig.cmake.in
+++ b/cmake/spzConfig.cmake.in
@@ -1,5 +1,10 @@
 @PACKAGE_INIT@
 
+if(NOT "@BUILD_SHARED_LIBS@")
+    include(CMakeFindDependencyMacro)
+    find_dependency(ZLIB)
+endif()
+
 include(${CMAKE_CURRENT_LIST_DIR}/spzConfigVersion.cmake)
 message(STATUS "Found spz ${PACKAGE_VERSION}")
 


### PR DESCRIPTION
When using the CMake config for a static build, this is needed to resolve the `ZLIB::ZLIB` link library of spz.