### PR TITLE
Add spz::spz alias target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(spz_headers
 
 # create the library and configure it
 add_library(spz ${spz_sources})
+add_library(spz::spz ALIAS spz)
 
 target_link_libraries(spz PRIVATE ZLIB::ZLIB)
 


### PR DESCRIPTION
Downstream may use spz via find_package or as a subdir/(git-)submodule. The former provides `spz::spz`, and this change makes the same target name available for the embedded build.