### PR TITLE
Add BUILD_SHARED_LIBS CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ project(spz
 
 include(GNUInstallDirs)
 
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+
 # zlib is required to build the project
 find_package(ZLIB REQUIRED)
 


### PR DESCRIPTION
I recently added SPZ as a package in Conda Forge and we needed to add this patch to enable building things as a shared library. See https://github.com/conda-forge/staged-recipes/pull/30542 for more details.

[`BUILD_SHARED_LIBS`](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html) is the CMake option for conveniently controlling this behavior.

