### PR TITLE
Add GitHub Action configuration to build on Windows, OSX, and Ubuntu

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -6,4 +6,5 @@ dependencies:
   - compilers
   - ninja
   - cmake
+  - zlib
 

--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -1,0 +1,9 @@
+name: build
+channels:
+  - conda-forge
+dependencies:
+  - conda
+  - compilers
+  - ninja
+  - cmake
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,6 @@ jobs:
      - name: "There are no tests :spoon:"
        shell: bash -l {0}
        run: |
-          "There are no tests"
+          echo "There are no tests"
        working-directory: ./build
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,6 @@ jobs:
            init-shell: bash
            environment-file: .github/environment.yml
            environment-name: "build"
-           cache-environment: true
-           cache-downloads: true
 
      - name: Setup
        shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build:
-    name: OS ${{ matrix.os }} with BUILD_SHARED_LIBS=${{matrix.shared}}
+    name: ${{ matrix.os }} with BUILD_SHARED_LIBS=${{matrix.shared}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -61,6 +61,12 @@ jobs:
        shell: bash -l {0}
        run: |
           ninja
+       working-directory: ./build
+
+     - name: Install
+       shell: bash -l {0}
+       run: |
+          ninja install
        working-directory: ./build
 
      - name: "There are no tests :spoon:"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,71 @@
+
+name: Test
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: OS ${{ matrix.os }} with BUILD_SHARED_LIBS=${{matrix.shared}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        shared: [ON, OFF]
+
+    steps:
+     - uses: actions/checkout@v4
+     - uses: ilammy/msvc-dev-cmd@v1
+       if: matrix.os == 'windows-latest'
+     - name: Support longpaths
+       run: git config --system core.longpaths true
+       if: matrix.os == 'windows-latest'
+     - uses: mamba-org/setup-micromamba@v2
+       with:
+           init-shell: bash
+           environment-file: .github/environment.yml
+           environment-name: "build"
+           cache-environment: true
+           cache-downloads: true
+
+     - name: Setup
+       shell: bash -l {0}
+       run: |
+           mkdir build
+
+     - name: CMake
+       shell: bash -l {0}
+       env:
+        BUILD_SHARED_LIBS: ${{ matrix.shared }}
+
+       run: |
+
+        if [ "$RUNNER_OS" == "Windows" ]; then
+        export CC=cl.exe
+        export CXX=cl.exe
+        fi
+
+        cmake   -G "Ninja"  \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS \
+              -DBUILD_TESTING=ON \
+              -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
+              ..
+
+
+       working-directory: ./build
+
+     - name: Compile
+       shell: bash -l {0}
+       run: |
+          ninja
+       working-directory: ./build
+
+     - name: "There are no tests :spoon:"
+       shell: bash -l {0}
+       run: |
+          "There are no tests"
+       working-directory: ./build
+


### PR DESCRIPTION
This adds a [GHA](https://github.com/features/actions) configuration to build native on Windows, OSX, and Ubuntu. 