### PR TITLE
Use size_t for finding `medianVolume` to eliminate integer comparison warning

### DIFF
--- a/src/cc/splat-types.h
+++ b/src/cc/splat-types.h
@@ -171,12 +171,12 @@ struct GaussianCloud {
     // axis. Scales are stored on a log scale, and exp(x) * exp(y) * exp(z) = exp(x + y + z). So we
     // can sort by value = (x + y + z) and compute volume = 4/3 * pi * exp(value) later.
     std::vector<float> scaleSums;
-    for (int32_t i = 0; i < scales.size(); i += 3) {
+    for (size_t i = 0; i < scales.size(); i += 3) {
       float sum = scales[i] + scales[i + 1] + scales[i + 2];
       scaleSums.push_back(sum);
     }
     std::sort(scaleSums.begin(), scaleSums.end());
-    float median = scaleSums[(int32_t)(scaleSums.size() / 2)];
+    float median = scaleSums[scaleSums.size() / 2];
     return (M_PI * 4 / 3) * exp(median);
   }
 };


### PR DESCRIPTION
clang 19.1.7 complains about `medianVolume`:

```
splat-types.h:174:27: warning: comparison of integers of different signs: 'int32_t' (aka 'int') and 'size_type' (aka 'unsigned long') [-Wsign-compare]
  174 |     for (int32_t i = 0; i < scales.size(); i += 3) {
      |
```

Maybe it would be better to use `std::vector<float>::size_type` here. Let me know and I can switch it.