### PR TITLE
Fix PIC compilation error when building Python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ project(spz
 
 include(GNUInstallDirs)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+
 # zlib is required to build the project
 find_package(ZLIB REQUIRED)
 


### PR DESCRIPTION
## Description
This PR fixes a compilation error that occurs when building the Python bindings on Linux systems.

## Problem
When running `pip install .`, the build fails with the following error:
relocation R_X86_64_PC32 against symbol `stdout@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC

## Solution
Added `set(CMAKE_POSITION_INDEPENDENT_CODE ON)` to enable position-independent code for all targets. This is required when static libraries are linked into shared libraries (Python extensions).

## Testing
- Tested on Ubuntu 20.04 with Python 3.12
- Build completes successfully after this change
- Python module imports correctly

Fixes #[issue_number] (if there's an existing issue)
