### PR TITLE
Add overload for `loadSpz` to take byte pointer

### DIFF
--- a/src/cc/load-spz.cc
+++ b/src/cc/load-spz.cc
@@ -635,6 +635,10 @@ GaussianCloud loadSpz(const std::vector<uint8_t> &data, const UnpackOptions &o) 
   return unpackGaussians(loadSpzPacked(data), o);
 }
 
+GaussianCloud loadSpz(const uint8_t *data, int32_t size, const UnpackOptions &o) {
+  return unpackGaussians(loadSpzPacked(data, size), o);
+}
+
 bool saveSpz(const GaussianCloud &g, const PackOptions &o, const std::string &filename) {
   std::vector<uint8_t> data;
   if (!saveSpz(g, o, &data)) {

--- a/src/cc/load-spz.h
+++ b/src/cc/load-spz.h
@@ -85,6 +85,9 @@ bool saveSpz(
 // Loads Gaussian splat from a file in packed format
 GaussianCloud loadSpz(const std::string &filename, const UnpackOptions &o);
 
+// Loads Gaussian splat from a byte pointer in packed format.
+GaussianCloud loadSpz(const uint8_t *data, int32_t size, const UnpackOptions &options);
+
 // Saves Gaussian splat data in .ply format
 bool saveSplatToPly(
   const spz::GaussianCloud &gaussians, const PackOptions &options, const std::string &filename);


### PR DESCRIPTION
`loadSpz` has two available overloads: one taking a vector of bytes, and one taking a filename. In our use case, [we're loading SPZ from a glTF file](https://github.com/CesiumGS/cesium-native/blob/34cc5236a48bc18c71eb6c4a5cd0b1f12f3d490d/CesiumGltfReader/src/decodeSpz.cpp#L74), which means the data we're loading could be from a subset of a larger vector of bytes. It would be fairly inefficient to copy over all of this data to pass it to `loadSpz`, especially considering that internally, `loadSpz` is taking that passed-in vector and turning it into a pointer and a length anyways. This change just adds an overload to be able to directly pass a pointer and length to `loadSpz`.