### PR TITLE
Reinstate Backwards Compatibility Writing

### DIFF
--- a/src/cc/load-spz.cc
+++ b/src/cc/load-spz.cc
@@ -213,6 +213,35 @@ struct membuf : std::streambuf {
 
 }  // namespace
 
+bool compressGzipped(const uint8_t *data, size_t size, std::vector<uint8_t> *out) {
+  std::vector<uint8_t> buffer(8192);
+  z_stream stream = {};
+  if (deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 16 + MAX_WBITS, 9, Z_DEFAULT_STRATEGY)
+      != Z_OK) {
+    return false;
+  }
+  out->clear();
+  out->reserve(size / 4);
+  stream.next_in = const_cast<Bytef *>(reinterpret_cast<const Bytef *>(data));
+  stream.avail_in = static_cast<uInt>(size);
+  bool success = false;
+  while (true) {
+    stream.next_out = buffer.data();
+    stream.avail_out = static_cast<uInt>(buffer.size());
+    int32_t res = deflate(&stream, Z_FINISH);
+    if (res != Z_OK && res != Z_STREAM_END) {
+      break;
+    }
+    out->insert(out->end(), buffer.data(), buffer.data() + buffer.size() - stream.avail_out);
+    if (res == Z_STREAM_END) {
+      success = true;
+      break;
+    }
+  }
+  deflateEnd(&stream);
+  return success;
+}
+
 bool compressZstd(const uint8_t *data, size_t size, std::vector<uint8_t> *out,
                   int compressionLevel = 12) {
   size_t const bound = ZSTD_compressBound(size);
@@ -705,6 +734,46 @@ bool decompressNgspStreams(const uint8_t *data, size_t size,
   return true;
 }
 
+bool compressNgspStreams(const std::vector<std::pair<const uint8_t *, size_t>> &srcs,
+                         std::vector<std::vector<uint8_t>> *chunks,
+                         std::vector<uint64_t> *uncompressedSizes) {
+#if defined(__EMSCRIPTEN__)
+  // TODO: Add support for parallel compression on WASM.
+  for (const auto &s : srcs) {
+    if (s.second == 0) continue;
+    uncompressedSizes->push_back(s.second);
+    std::vector<uint8_t> chunk;
+    if (!compressZstd(s.first, s.second, &chunk)) {
+      SpzLog("[SPZ ERROR] compressNgspStreams: ZSTD compression failed");
+      return false;
+    }
+    chunks->push_back(std::move(chunk));
+  }
+#else
+  std::vector<std::future<std::vector<uint8_t>>> futures;
+  for (const auto &s : srcs) {
+    if (s.second == 0) continue;
+    uncompressedSizes->push_back(s.second);
+    futures.push_back(std::async(std::launch::async, [s]() -> std::vector<uint8_t> {
+      std::vector<uint8_t> chunk;
+      if (!compressZstd(s.first, s.second, &chunk)) {
+        SpzLog("[SPZ ERROR] compressNgspStreams: ZSTD compression failed");
+        return {};
+      }
+      return chunk;
+    }));
+  }
+  for (auto &f : futures) {
+    chunks->push_back(f.get());
+    if (chunks->back().empty()) {
+      SpzLog("[SPZ ERROR] compressNgspStreams: compression failed");
+      return false;
+    }
+  }
+#endif
+  return true;
+}
+
 PackedGaussians loadPackedGaussiansFromNgsp(const uint8_t *data, size_t size,
                                             const NgspFileHeader &header) {
   const int32_t numPoints = header.numPoints;
@@ -817,19 +886,21 @@ PackedGaussians deserializePackedGaussians(std::istream &in) {
 }
 
 bool saveSpz(const GaussianCloud &g, const PackOptions &o, std::vector<uint8_t> *out) {
-  PackOptions opts = o;
-  opts.version = LATEST_SPZ_HEADER_VERSION;
-  PackedGaussians packed = packGaussians(g, opts);
+  PackedGaussians packed = packGaussians(g, o);
 
   if (g.numPoints > 0 && packed.numPoints == 0) {
     return false;
   }
 
-  struct Stream {
-    const uint8_t *data;
-    size_t size;
-  };
-  const Stream streams[] = {
+  if (o.version < MIN_ZSTD_SPZ_HEADER_VERSION) {
+    // Legacy gzip path for versions 1–3.
+    std::stringstream ss;
+    serializePackedGaussians(packed, &ss);
+    const std::string data = ss.str();
+    return compressGzipped(reinterpret_cast<const uint8_t *>(data.data()), data.size(), out);
+  }
+
+  const std::vector<std::pair<const uint8_t *, size_t>> srcs = {
     {packed.positions.data(), packed.positions.size()},
     {packed.alphas.data(),    packed.alphas.size()},
     {packed.colors.data(),    packed.colors.size()},
@@ -838,53 +909,16 @@ bool saveSpz(const GaussianCloud &g, const PackOptions &o, std::vector<uint8_t> 
     {packed.sh.data(),        packed.sh.size()},
   };
 
-  std::vector<uint64_t> uncompressedSizes;
   std::vector<std::vector<uint8_t>> chunks;
-
-#if defined(__EMSCRIPTEN__)
-  // TODO: Add support for parallel compression on WASM.
-  for (const auto &s : streams) {
-    if (s.size == 0) {
-      continue;
-    }
-    uncompressedSizes.push_back(s.size);
-    std::vector<uint8_t> chunk;
-    if (!compressZstd(s.data, s.size, &chunk)) {
-      SpzLog("[SPZ ERROR] saveSpz: ZSTD compression failed");
-      return false;
-    }
-    chunks.push_back(std::move(chunk));
+  std::vector<uint64_t> uncompressedSizes;
+  if (!compressNgspStreams(srcs, &chunks, &uncompressedSizes)) {
+    return false;
   }
-#else
-  std::vector<std::future<std::vector<uint8_t>>> futures;
-  for (const auto &s : streams) {
-    if (s.size == 0) {
-      continue;
-    }
-    uncompressedSizes.push_back(s.size);
-    futures.push_back(std::async(std::launch::async, [s]() -> std::vector<uint8_t> {
-      std::vector<uint8_t> chunk;
-      if (!compressZstd(s.data, s.size, &chunk)) {
-        SpzLog("[SPZ ERROR] saveSpz: ZSTD compression failed");
-        return {};
-      }
-      return chunk;
-    }));
-  }
-
-  for (auto &f : futures) {
-    chunks.push_back(f.get());
-    if (chunks.back().empty()) {
-      SpzLog("[SPZ ERROR] saveSpz: compression failed");
-      return false;
-    }
-  }
-#endif
 
   const uint8_t numStreams = static_cast<uint8_t>(chunks.size());
   const uint32_t tocByteOffset = static_cast<uint32_t>(sizeof(NgspFileHeader));
   NgspFileHeader header;
-  header.version        = LATEST_SPZ_HEADER_VERSION;
+  header.version        = o.version;
   header.numPoints      = packed.numPoints;
   header.shDegree       = packed.shDegree;
   header.fractionalBits = packed.fractionalBits;
@@ -892,7 +926,7 @@ bool saveSpz(const GaussianCloud &g, const PackOptions &o, std::vector<uint8_t> 
   header.numStreams     = numStreams;
   header.tocByteOffset  = tocByteOffset;
 
-  // Write plaintext zone: [header][TOC]
+  // Write plaintext zone: [header][*][TOC]
   out->resize(tocByteOffset + numStreams * 2 * sizeof(uint64_t));
   uint8_t *buf = out->data();
   std::memcpy(buf, &header, sizeof(header));

--- a/src/cc/load-spz.h
+++ b/src/cc/load-spz.h
@@ -185,6 +185,8 @@ GaussianCloud loadSplatFromPly(const std::string &filename, const UnpackOptions 
 
 void serializePackedGaussians(const PackedGaussians &packed, std::ostream *out);
 
+bool compressGzipped(const uint8_t *data, size_t size, std::vector<uint8_t> *out);
+
 // Returns true if the build has extension support enabled, false otherwise
 bool hasExtensionSupport();
 }  // namespace spz

--- a/tests/python/test_version_compatibility.py
+++ b/tests/python/test_version_compatibility.py
@@ -1,9 +1,11 @@
 """Tests for SPZ version compatibility and regression."""
 
 import os
+import struct
 import tempfile
 
 import numpy as np
+import pytest
 
 import spz
 from test_utils import times, sh_epsilon
@@ -25,40 +27,69 @@ def test_pack_options_version_property():
     opts.version = 1
     assert opts.version == 1
 
-def test_ngsp_v4_round_trip():
-    """Test that saving and loading an NGSP v4 file round-trips correctly."""
+@pytest.mark.parametrize("version,expected_magic", [
+    (2, b"\x1f\x8b"),
+    (3, b"\x1f\x8b"),
+    (4, b"NGSP"),
+])
+def test_all_versions_round_trip(version, expected_magic):
+    """All writable versions produce the correct file format and round-trip all attributes."""
+    num_points = 8
+    rng = np.random.default_rng(version)  # deterministic per version
+
     cloud = spz.GaussianCloud()
     cloud.sh_degree = 1
-
-    num_points = 10
-    rng = np.random.default_rng(0)
     cloud.positions = rng.uniform(-5.0, 5.0, size=num_points * 3).astype(np.float32)
     cloud.scales = rng.uniform(-2.0, 2.0, size=num_points * 3).astype(np.float32)
     cloud.rotations = rng.uniform(-1.0, 1.0, size=num_points * 4).astype(np.float32)
-    cloud.alphas = rng.uniform(-2.0, 2.0, size=num_points).astype(np.float32)
+    cloud.alphas = rng.uniform(-1.0, 1.0, size=num_points).astype(np.float32)
     cloud.colors = rng.uniform(0.0, 1.0, size=num_points * 3).astype(np.float32)
     cloud.sh = rng.uniform(-0.5, 0.5, size=num_points * 9).astype(np.float32)
 
     opts = spz.PackOptions()
-    filename = os.path.join(tempfile.gettempdir(), "ngsp_v4_round_trip.spz")
+    opts.version = version
+    filename = os.path.join(tempfile.gettempdir(), f"all_versions_v{version}.spz")
     assert spz.save_spz(cloud, opts, filename) is True
 
-    # Verify NGSP magic bytes at the start of the file
+    # Verify the file starts with the expected magic bytes for this version.
     with open(filename, "rb") as f:
-        header = f.read(4)
-    assert header == b"NGSP", f"Expected NGSP magic, got {header!r}"
+        magic = f.read(len(expected_magic))
+    assert magic == expected_magic, (
+        f"v{version}: expected magic {expected_magic!r}, got {magic!r}"
+    )
 
     loaded = spz.load_spz(filename, spz.UnpackOptions())
     assert loaded.num_points == num_points
     assert loaded.sh_degree == 1
-    np.testing.assert_allclose(loaded.positions, cloud.positions, atol=1/2048.0)
-    np.testing.assert_allclose(loaded.scales, cloud.scales, atol=1/32.0)
-    # Colors use a scaled encoding: round(x * colorScale * 255 + 0.5 * 255) where colorScale=0.15.
-    np.testing.assert_allclose(loaded.colors, cloud.colors, atol=1.0 / (2 * 0.15 * 255))
-    # Alpha is stored as 8-bit sigmoid; at large magnitudes the quantization error exceeds 0.01.
-    np.testing.assert_allclose(loaded.alphas, cloud.alphas, atol=0.02)
-    # SH degree 1 uses 5-bit quantization by default.
-    np.testing.assert_allclose(loaded.sh, cloud.sh, atol=1/32.0 + 1/255.0)
+
+    np.testing.assert_allclose(loaded.positions, cloud.positions, atol=1/2048.0,
+                               err_msg=f"v{version}: positions")
+    np.testing.assert_allclose(loaded.scales, cloud.scales, atol=1/32.0,
+                               err_msg=f"v{version}: scales")
+    np.testing.assert_allclose(loaded.colors, cloud.colors, atol=1.0/(2*0.15*255),
+                               err_msg=f"v{version}: colors")
+    np.testing.assert_allclose(loaded.alphas, cloud.alphas, atol=0.02,
+                               err_msg=f"v{version}: alphas")
+    np.testing.assert_allclose(loaded.sh, cloud.sh, atol=1/32.0 + 1/255.0,
+                               err_msg=f"v{version}: sh")
+
+    # Rotations: verify each quaternion is normalized and preserves the rotation.
+    # - NOTE: v2 uses first-three 8-bit encoding; v3+ uses smallest-three 10-bit.)
+    test_vec = np.array([1.0, 0.0, 0.0])
+    for i in range(num_points):
+        q_orig = cloud.rotations[i*4:(i+1)*4]
+        q_loaded = loaded.rotations[i*4:(i+1)*4]
+
+        # v2 stores x,y,z as 8-bit signed integers (max error ≈ 1/128 per component).
+        norm_tol = 0.01 if version == 2 else 1e-4
+        assert abs(np.linalg.norm(q_loaded) - 1.0) < norm_tol, f"v{version}: rotation {i} not unit"
+        q_orig_norm = q_orig / np.linalg.norm(q_orig)
+        cosine = abs(np.dot(times(q_orig_norm, test_vec), times(q_loaded, test_vec)))
+        cosine /= np.linalg.norm(times(q_orig_norm, test_vec)) * np.linalg.norm(times(q_loaded, test_vec))
+        
+        # v2 uses 8-bit x,y,z encoding (lower precision); v3+ uses smallest-three 10-bit.
+        threshold = 0.99 if version == 2 else 0.999
+        assert cosine > threshold, f"v{version}: rotation {i} cosine similarity {cosine:.4f} < {threshold}"
 
 
 def test_spz_version_3_quaternion_encoding():


### PR DESCRIPTION
# Context

Previous PR #73 meant to keep backwards compatibility for writing SPZ v2 and v3 through the packed options.

# Test

## Unit Test
Added simple python tests to write different versions with packed options and check the magic number.

## Other Tests
Build a handful of spzs with different packed options using the API, and ran `spz_info` to confirm the version.
