### PR TITLE
Move V4 Extensions to Memory Space between Header and TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,12 @@ Version 4 uses ZSTD compression with a 32-byte plaintext header. Each attribute 
 
 ```
 Bytes  0–31:              NgspFileHeader (32 bytes, plaintext)
-Bytes  32..(32+N*16-1):   TOC — N × [compressedSize u64, uncompressedSize u64]
-Bytes  (32+N*16)..end:    N independent ZSTD-compressed attribute streams
+Bytes  32..(tbo-1):       Extension ILV records, if flags & 0x2  (variable)
+Bytes  tbo..(tbo+N*16-1): TOC — N × [compressedSize u64, uncompressedSize u64]
+Bytes  (tbo+N*16)..end:   N independent ZSTD-compressed attribute streams
 ```
+
+`tbo` = `tocByteOffset` from the header. When no extensions are present, `tbo = 32`.
 
 ### Header (version 4)
 
@@ -150,7 +153,7 @@ All values are little-endian.
 5. **fractionalBits**: The number of bits used for the fractional part of fixed-point coordinates.
 6. **flags**: Bit field.
    - `0x1`: splat was trained with [antialiasing](https://niujinshuchong.github.io/mip-splatting/).
-   - `0x2`: whether the stream contains vendor-specific extensions after the gaussian data.
+   - `0x2`: the header zone contains vendor-specific extension records (see [Extensions](#extensions)).
 7. **numStreams**: Number of ZSTD-compressed attribute streams following the TOC. Typically 6 (positions, alphas, colors, scales, rotations, spherical harmonics).
 8. **tocByteOffset**: Byte offset from the start of the file to the Table of Contents. Everything before `tocByteOffset` is plaintext.
 9. **reserved**: Must be zero.
@@ -222,7 +225,7 @@ This allows users to trade off between file size and quality. The library mainta
 
 ### Extensions
 
-SPZ supports vendor-specific extensions (e.g. camera limits) so multiple vendors can coexist in the same file. The extension stream uses a per-record length so unknown types are skipped. For the extension format and how to add or use extensions, see [extensions/README.md](extensions/README.md).
+SPZ supports vendor-specific extensions (e.g. camera limits) so multiple vendors can coexist in the same file. In version 4, extensions are stored as ILV (type + length + value) records in the plaintext header zone between the fixed header and the TOC — parsers that don't recognize an extension type skip it by length. For the extension format and how to add or use extensions, see [extensions/README.md](extensions/README.md).
 
 ### Camera Orbit Limitation
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -2,9 +2,9 @@
 
 Extensions allow vendor-specific or application-specific data to be stored in SPZ files alongside the core Gaussian splat data. Multiple extensions from different vendors can coexist in the same file; unknown extension types are skipped during parsing so readers only need to understand the extensions they care about.
 
-## Extension stream format
+## Extension record format
 
-Extensions are stored at the end of the packed SPZ stream (after Gaussian data). The format is **length‑delimited per record**:
+Extensions use a **length-delimited per-record** format regardless of where they are stored:
 
 ```
 [ u32 type ][ u32 byteLength ][ payload... ]
@@ -14,7 +14,7 @@ Extensions are stored at the end of the packed SPZ stream (after Gaussian data).
 - **byteLength** — 4-byte length in bytes of the following payload.
 - **payload** — exactly `byteLength` bytes of extension-specific data.
 
-Records repeat back-to-back until end-of-stream. There is no separate record count or terminator; EOF after the last payload ends the extension block.
+Records repeat back-to-back. Extensions occupy the plaintext header zone between the fixed 32-byte `NgspFileHeader` and the Table of Contents. The block spans bytes `[32, tocByteOffset)`, where `tocByteOffset` is read directly from the header — no need to decompress anything to locate or parse extensions.
 
 ### Why length-delimited?
 
@@ -44,8 +44,9 @@ Example: Adobe vendor ID `0xADBE`, extension index 2 → `0xADBE0002u` (`SPZ_ADO
 If an SPZ file that contains extensions is loaded by a library build that was **not** built with extension support (`SPZ_BUILD_EXTENSIONS` is OFF, the default):
 
 - **The load still succeeds.** Core Gaussian splat data (positions, colors, SH, etc.) is read and returned as usual.
-- **Extension data is ignored.** The header’s extension flag is read, but the extension block is not parsed or skipped. A warning is logged:  
-  `[SPZ WARNING] deserializePackedGaussians: the stream has extensions but extensions are unsupported in the current build of SPZ`
+- **Extension data is ignored.** The header’s extension flag is read, but the extension block is not parsed. A warning is logged. The exact message depends on the file format:
+  - NGSP v4: `[SPZ WARNING] loadSpzPacked: file has header extensions but extension support is disabled`
+  - Legacy gzip: `[SPZ WARNING] deserializePackedGaussians: the stream has extensions but extensions are unsupported in the current build of SPZ`
 - **Returned clouds have no extensions.** `PackedGaussians` and `GaussianCloud` in a no-extension build do not have an `extensions` member; the loaded result simply omits any extension data.
 
 So builds without extensions can safely load files that contain extensions; they get the core data and drop the rest. To preserve or use extension data, build with `-DSPZ_BUILD_EXTENSIONS=ON` and use a build that includes the extension sources.
@@ -58,7 +59,7 @@ So builds without extensions can safely load files that contain extensions; they
    CMake: `-DSPZ_BUILD_EXTENSIONS=ON`.
 
 2. **Load/Save**  
-   Extensions are part of `PackedGaussians` and `GaussianCloud`. When you load (e.g. `loadSpz`, `loadSpzPacked`) or save (`saveSpz`, `serializePackedGaussians`), the extension list is read/written automatically.
+   Extensions are part of `PackedGaussians` and `GaussianCloud`. When you call `loadSpz` / `loadSpzPacked` or `saveSpz`, the extension list is read/written automatically. For version 4 and above, `saveSpz` writes extensions into the plaintext header zone.
 
 3. **Access a known extension**  
    Use `findExtensionByType<T>()`. Include the header for the concrete extension type you use:

--- a/src/cc/load-spz.cc
+++ b/src/cc/load-spz.cc
@@ -809,6 +809,20 @@ PackedGaussians loadPackedGaussiansFromNgsp(const uint8_t *data, size_t size,
     return {};
   }
 
+  if ((header.flags & FlagHasExtensions) != 0) {
+    const size_t extStart = sizeof(NgspFileHeader);
+    const size_t extEnd = header.tocByteOffset;
+    if (extStart < extEnd && extEnd <= size) {
+#ifdef SPZ_BUILD_EXTENSIONS
+      std::string extStr(reinterpret_cast<const char *>(data + extStart), extEnd - extStart);
+      std::istringstream extStream(std::move(extStr));
+      readAllExtensions(extStream, result.extensions);
+#else
+      SpzLog("[SPZ WARNING] loadSpzPacked: file has header extensions but extension support is disabled");
+#endif
+    }
+  }
+
   return result;
 }
 
@@ -900,6 +914,16 @@ bool saveSpz(const GaussianCloud &g, const PackOptions &o, std::vector<uint8_t> 
     return compressGzipped(reinterpret_cast<const uint8_t *>(data.data()), data.size(), out);
   }
 
+  std::vector<uint8_t> extensionData;
+#ifdef SPZ_BUILD_EXTENSIONS
+  if (!packed.extensions.empty()) {
+    std::ostringstream extStream;
+    writeAllExtensions(packed.extensions, extStream);
+    const std::string &s = extStream.str();
+    extensionData.assign(s.begin(), s.end());
+  }
+#endif
+
   const std::vector<std::pair<const uint8_t *, size_t>> srcs = {
     {packed.positions.data(), packed.positions.size()},
     {packed.alphas.data(),    packed.alphas.size()},
@@ -916,20 +940,27 @@ bool saveSpz(const GaussianCloud &g, const PackOptions &o, std::vector<uint8_t> 
   }
 
   const uint8_t numStreams = static_cast<uint8_t>(chunks.size());
-  const uint32_t tocByteOffset = static_cast<uint32_t>(sizeof(NgspFileHeader));
+  const uint32_t tocByteOffset = static_cast<uint32_t>(sizeof(NgspFileHeader) + extensionData.size());
   NgspFileHeader header;
   header.version        = o.version;
   header.numPoints      = packed.numPoints;
   header.shDegree       = packed.shDegree;
   header.fractionalBits = packed.fractionalBits;
-  header.flags          = static_cast<uint8_t>(packed.antialiased ? FlagAntialiased : 0);
+  header.flags          = static_cast<uint8_t>(packed.antialiased ? FlagAntialiased : 0)
+#ifdef SPZ_BUILD_EXTENSIONS
+      | static_cast<uint8_t>(extensionData.empty() ? 0 : FlagHasExtensions)
+#endif
+      ;
   header.numStreams     = numStreams;
   header.tocByteOffset  = tocByteOffset;
 
-  // Write plaintext zone: [header][*][TOC]
+  // Write plaintext zone: [header][extensions][TOC]
   out->resize(tocByteOffset + numStreams * 2 * sizeof(uint64_t));
   uint8_t *buf = out->data();
   std::memcpy(buf, &header, sizeof(header));
+  if (!extensionData.empty()) {
+    std::memcpy(buf + sizeof(NgspFileHeader), extensionData.data(), extensionData.size());
+  }
   for (uint8_t i = 0; i < numStreams; i++) {
     const uint64_t cs = static_cast<uint64_t>(chunks[i].size());
     const uint64_t us = uncompressedSizes[i];

--- a/tests/python/test_extensions.py
+++ b/tests/python/test_extensions.py
@@ -1,0 +1,96 @@
+"""Tests for SPZ extension round-trip through NGSP v4 and legacy gzip formats."""
+
+import gzip
+import io
+import os
+import struct
+import tempfile
+
+import numpy as np
+import pytest
+
+import spz
+
+
+def _make_cloud(num_points=5, seed=0):
+    rng = np.random.default_rng(seed)
+    cloud = spz.GaussianCloud()
+    cloud.sh_degree = 1
+    cloud.positions = rng.uniform(-1.0, 1.0, size=num_points * 3).astype(np.float32)
+    cloud.scales = rng.uniform(-2.0, 2.0, size=num_points * 3).astype(np.float32)
+    cloud.rotations = rng.uniform(-1.0, 1.0, size=num_points * 4).astype(np.float32)
+    cloud.alphas = rng.uniform(-1.0, 1.0, size=num_points).astype(np.float32)
+    cloud.colors = rng.uniform(0.0, 1.0, size=num_points * 3).astype(np.float32)
+    cloud.sh = rng.uniform(-0.5, 0.5, size=num_points * 9).astype(np.float32)
+    return cloud
+
+
+@pytest.mark.skipif(not spz.has_extension_support(), reason="built without extension support")
+def test_safe_orbit_extension_round_trip():
+    """SafeOrbit extension survives a save/load round-trip"""
+    cloud = _make_cloud()
+
+    ext = spz.SpzExtensionSafeOrbitCameraAdobe()
+    ext.safe_orbit_elevation_min = -0.5
+    ext.safe_orbit_elevation_max = 1.2
+    ext.safe_orbit_radius_min = 0.3
+    cloud.extensions = [ext]
+
+    filename = os.path.join(tempfile.gettempdir(), "ext_round_trip.spz")
+    assert spz.save_spz(cloud, spz.PackOptions(), filename) is True
+
+    # FlagHasExtensions (0x2) must be set in the header flags byte (offset 14).
+    with open(filename, "rb") as f:
+        header = f.read(32)
+    flags = header[14]
+    assert flags & 0x2, f"FlagHasExtensions not set in saved file (flags=0x{flags:02x})"
+
+    loaded = spz.load_spz(filename, spz.UnpackOptions())
+    assert loaded.num_points == cloud.num_points
+    assert len(loaded.extensions) == 1
+
+    loaded_ext = loaded.extensions[0]
+    assert isinstance(loaded_ext, spz.SpzExtensionSafeOrbitCameraAdobe)
+    assert abs(loaded_ext.safe_orbit_elevation_min - ext.safe_orbit_elevation_min) < 1e-5
+    assert abs(loaded_ext.safe_orbit_elevation_max - ext.safe_orbit_elevation_max) < 1e-5
+    assert abs(loaded_ext.safe_orbit_radius_min - ext.safe_orbit_radius_min) < 1e-5
+
+
+@pytest.mark.skipif(not spz.has_extension_support(), reason="built without extension support")
+def test_no_extension_flag_when_no_extensions():
+    """FlagHasExtensions must NOT be set when the cloud has no extensions."""
+    cloud = _make_cloud()
+    cloud.extensions = []
+
+    filename = os.path.join(tempfile.gettempdir(), "no_ext.spz")
+    assert spz.save_spz(cloud, spz.PackOptions(), filename) is True
+
+    with open(filename, "rb") as f:
+        header = f.read(32)
+    flags = header[14]
+    assert not (flags & 0x2), f"FlagHasExtensions unexpectedly set (flags=0x{flags:02x})"
+
+
+@pytest.mark.skipif(not spz.has_extension_support(), reason="built without extension support")
+def test_toc_byte_offset_advances_with_extensions():
+    """tocByteOffset must be > 32 when extensions are correctly saved, 32 when absent."""
+    cloud = _make_cloud()
+
+    # Without extensions
+    filename_no_ext = os.path.join(tempfile.gettempdir(), "toc_no_ext.spz")
+    cloud.extensions = []
+    assert spz.save_spz(cloud, spz.PackOptions(), filename_no_ext) is True
+    with open(filename_no_ext, "rb") as f:
+        hdr_no_ext = f.read(32)
+    tbo_no_ext = struct.unpack_from("<I", hdr_no_ext, 16)[0]
+    assert tbo_no_ext == 32, f"Expected tocByteOffset=32 with no extensions, got {tbo_no_ext}"
+
+    # With extension
+    ext = spz.SpzExtensionSafeOrbitCameraAdobe()
+    cloud.extensions = [ext]
+    filename_ext = os.path.join(tempfile.gettempdir(), "toc_with_ext.spz")
+    assert spz.save_spz(cloud, spz.PackOptions(), filename_ext) is True
+    with open(filename_ext, "rb") as f:
+        hdr_ext = f.read(32)
+    tbo_ext = struct.unpack_from("<I", hdr_ext, 16)[0]
+    assert tbo_ext > 32, f"Expected tocByteOffset>32 with extension, got {tbo_ext}"


### PR DESCRIPTION
# Context

For v4, hoping to move extension data to the space between the header and TOC. This makes the uncompressed data sit nicely with each other, and makes it more clear when it comes to peeking at the extension data in an spz file without fully decompressing it.

# Test plan                                           
  - pytest tests/python/ passes (49 tests) with SPZ_BUILD_EXTENSIONS=ON                                  
  - (Local Changes) ply_to_spz input.ply out.spz --elevation-min -0.5 --elevation-max 1.2 --radius-min 0.3 produces a
  file with FlagHasExtensions set and tocByteOffset > 32 
  - (Local Changes) spz_info on a file with extensions prints the safe orbit fields
  - Renders fine with local changes to super splat
<img width="1292" height="852" alt="image" src="https://github.com/user-attachments/assets/1d4c3e35-da6e-4cd5-8555-9e17a809ccf8" />
