### PR TITLE
[feat] Expose fractionalBits in PackOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The `PackOptions` struct supports the following fields:
 - `version`: Version of the packed format (default: `4`)
 - `sh1Bits`: Number of quantization bits for SH degree 1 coefficients (default: 5, range: 1-8)
 - `shRestBits`: Number of quantization bits for SH degree 2+ coefficients (default: 4, range: 1-8)
+- `fractionalBits`: Number of fractional bits for fixed-point position coordinates (default: 12, range: 4-23). Positions are stored as 24-bit signed integers, so the per-axis representable range is ±2^(23-`fractionalBits`) and the resolution is 2^-`fractionalBits`. The decoder reads this value from the header, so any value in range round-trips. Values below 4 are rejected as too coarse for any plausible Gaussian-splat use case (e.g. N=3 gives 12.5 cm resolution over a 1048 km range).
 
 ## File Format
 

--- a/src/cc/load-spz.cc
+++ b/src/cc/load-spz.cc
@@ -328,6 +328,12 @@ PackedGaussians packGaussians(const GaussianCloud &g, const PackOptions &o) {
            o.sh1Bits, o.shRestBits);
     return {};
   }
+  if (o.fractionalBits < MIN_FRACTIONAL_BITS ||
+      o.fractionalBits > MAX_FRACTIONAL_BITS) {
+    SpzLog("[SPZ ERROR] fractionalBits must be in [%d, %d], got %d",
+           MIN_FRACTIONAL_BITS, MAX_FRACTIONAL_BITS, o.fractionalBits);
+    return {};
+  }
 
   const int32_t numPoints = g.numPoints;
   const int32_t shDim = dimForDegree(g.shDegree);
@@ -337,13 +343,14 @@ PackedGaussians packGaussians(const GaussianCloud &g, const PackOptions &o) {
   }
   CoordinateConverter c = coordinateConverter(o.from, CoordinateSystem::RUB);
 
-  // Use 12 bits for the fractional part of coordinates (~0.25 millimeter resolution). In the future
-  // we can use different values on a per-splat basis and still be compatible with the decoder.
+  // Per-axis representable range is +/- 2^(23 - fractionalBits); resolution is 2^-fractionalBits.
+  // The decoder reads fractionalBits from the file header, so any value the encoder
+  // accepts (MIN_FRACTIONAL_BITS..MAX_FRACTIONAL_BITS) round-trips through every existing reader.
   PackedGaussians packed;
   packed.version = o.version;
   packed.numPoints = g.numPoints;
   packed.shDegree = g.shDegree;
-  packed.fractionalBits = 12;
+  packed.fractionalBits = o.fractionalBits;
   packed.antialiased = g.antialiased;
   // Turn off quaternion-smallest-three for backward compatibility, since version 2 does not
   // support it.

--- a/src/cc/load-spz.h
+++ b/src/cc/load-spz.h
@@ -62,6 +62,28 @@ constexpr int SH_MAX_COEFFS = 24;
 constexpr int DEFAULT_SH1_BITS = 5;
 constexpr int DEFAULT_SH_REST_BITS = 4;
 
+// Number of bits used for the fractional part of fixed-point position
+// coordinates. Positions are stored as 24-bit signed fixed-point per axis, so
+// the representable range is +/- 2^(23 - fractionalBits). With the default 12,
+// this is ~0.25 mm resolution over a +/- 2048 m range.
+constexpr int DEFAULT_FRACTIONAL_BITS = 12;
+
+// Maximum number of fractional bits that fit in the 24-bit signed integer
+// representation of positions. At this maximum, all 23 value bits are
+// fractional and the per-axis representable range collapses to +/- 1.0.
+// Higher values would either silently truncate the encoded fixed-point value
+// (it would no longer fit in int24) or invoke undefined behavior in the
+// (1 << fractionalBits) computation used by both encode and decode.
+constexpr int MAX_FRACTIONAL_BITS = 23;
+
+// Minimum number of fractional bits accepted by the encoder. Below this the
+// resolution is too coarse for any realistic Gaussian-splat use case: at N=4
+// the per-axis range is +/- 524288 m and resolution is 6.25 cm, already
+// generous for aerial / city-scale scenes. N=3 has 12.5 cm resolution over a
+// 1048 km range, and the lower values get progressively worse -- almost
+// certainly a configuration mistake, so reject loudly instead.
+constexpr int MIN_FRACTIONAL_BITS = 4;
+
 // Latest version of the packed format, update this when changing the format.
 constexpr int LATEST_SPZ_HEADER_VERSION = 4;
 
@@ -140,6 +162,13 @@ struct PackOptions {
   // Unpacking doesn't need these values since g-unzipping already fills zero bits for quantized data.
   uint8_t sh1Bits = DEFAULT_SH1_BITS;     // Bits for SH degree 1 coefficients
   uint8_t shRestBits = DEFAULT_SH_REST_BITS;  // Bits for SH degree 2+ coefficients
+
+  // Number of fractional bits for fixed-point position coordinates. See
+  // DEFAULT_FRACTIONAL_BITS for the meaning. Must satisfy
+  // MIN_FRACTIONAL_BITS <= fractionalBits <= MAX_FRACTIONAL_BITS. The decoder
+  // reads this value from the file header, so any value in range is fully
+  // backward-compatible.
+  uint8_t fractionalBits = DEFAULT_FRACTIONAL_BITS;
 };
 
 struct UnpackOptions {

--- a/src/python/spz/spz.cc
+++ b/src/python/spz/spz.cc
@@ -115,6 +115,11 @@ static auto vector_setter = [](std::vector<float>& vec,
 NB_MODULE(spz, m) {
     m.doc() = "Python bindings for the spz library (Gaussian splatting).";
 
+    // Module-level constants exposing limits/defaults that callers may need.
+    m.attr("MIN_FRACTIONAL_BITS") = spz::MIN_FRACTIONAL_BITS;
+    m.attr("MAX_FRACTIONAL_BITS") = spz::MAX_FRACTIONAL_BITS;
+    m.attr("DEFAULT_FRACTIONAL_BITS") = spz::DEFAULT_FRACTIONAL_BITS;
+
     // -------------------------------------------------------------------------
     // Enums
     // Coordinate system enum with comprehensive documentation
@@ -159,7 +164,11 @@ NB_MODULE(spz, m) {
         .def_rw("sh1_bits", &spz::PackOptions::sh1Bits,
                 "Bits used for first-order spherical harmonics quantization")
         .def_rw("sh_rest_bits", &spz::PackOptions::shRestBits,
-                "Bits used for non-first-order spherical harmonics quantization");
+                "Bits used for non-first-order spherical harmonics quantization")
+        .def_rw("fractional_bits", &spz::PackOptions::fractionalBits,
+                "Number of fractional bits for fixed-point position coordinates "
+                "(spz.MIN_FRACTIONAL_BITS to spz.MAX_FRACTIONAL_BITS). "
+                "Higher = finer resolution, smaller representable range.");
 
     nb::class_<spz::UnpackOptions>(m, "UnpackOptions")
         .def(nb::init<>())

--- a/tests/python/test_pack_options_v4.py
+++ b/tests/python/test_pack_options_v4.py
@@ -1,0 +1,75 @@
+"""Tests for PackOptions.fractional_bits."""
+
+import struct
+
+import numpy as np
+import pytest
+
+import spz
+
+
+def _cloud(num_points=1000, extent=8.0, seed=0):
+    rng = np.random.default_rng(seed)
+    c = spz.GaussianCloud()
+    c.sh_degree = 1
+    c.positions = rng.uniform(-extent, extent, size=num_points * 3).astype(np.float32)
+    c.scales = rng.uniform(-2.0, 2.0, size=num_points * 3).astype(np.float32)
+    c.rotations = rng.uniform(-1.0, 1.0, size=num_points * 4).astype(np.float32)
+    c.alphas = rng.uniform(-3.0, 3.0, size=num_points).astype(np.float32)
+    c.colors = rng.uniform(-2.0, 2.0, size=num_points * 3).astype(np.float32)
+    c.sh = rng.uniform(-0.5, 0.5, size=num_points * 9).astype(np.float32)
+    return c
+
+
+def _save(cloud, tmp_path, **opts):
+    o = spz.PackOptions()
+    for k, v in opts.items():
+        setattr(o, k, v)
+    _save.counter += 1
+    path = str(tmp_path / f"out_{_save.counter}.spz")
+    return spz.save_spz(cloud, o, path), path
+
+_save.counter = 0
+
+
+def test_defaults_and_setters():
+    assert spz.MIN_FRACTIONAL_BITS == 4
+    assert spz.MAX_FRACTIONAL_BITS == 23
+    assert spz.DEFAULT_FRACTIONAL_BITS == 12
+    o = spz.PackOptions()
+    assert o.fractional_bits == 12
+    o.fractional_bits = 8
+    assert o.fractional_bits == 8
+
+
+@pytest.mark.parametrize("n", [4, 8, 12, 16, 20, 23])
+def test_fractional_bits_round_trip(n, tmp_path):
+    """Header echoes fractional_bits, and position error <= 2^-N."""
+    # Pick extent that fits in +/- 2^(23-N) (the representable range), capped
+    # at 8.0 for ergonomics. Without this cap, the encoder would refuse to
+    # save at N=23 (range +/- 1.0).
+    extent = min(8.0, 0.5 * 2.0 ** (23 - n))
+    cloud = _cloud(extent=extent)
+    orig = np.asarray(cloud.positions, dtype=np.float32).copy()
+    ok, path = _save(cloud, tmp_path, fractional_bits=n)
+    assert ok
+    # NgspFileHeader layout: magic[0..3], version[4..7], numPoints[8..11],
+    # shDegree[12], fractionalBits[13]. fractionalBits should echo `n`.
+    with open(path, "rb") as f:
+        magic, version, _, _, frac_bits = struct.unpack("<IIIBB", f.read(14))
+    assert magic == 0x5053474E and version == 4 and frac_bits == n
+    # Round-trip error bound: rounding to nearest at step 2^-N.
+    recovered = np.asarray(spz.load_spz(path).positions, dtype=np.float32)
+    max_err = float(np.max(np.abs(recovered - orig)))
+    assert max_err <= 2.0 ** -n, f"max_err={max_err:.6g} > 2^-{n}"
+
+
+@pytest.mark.parametrize("n", [
+    spz.MIN_FRACTIONAL_BITS - 1,
+    0,
+    spz.MAX_FRACTIONAL_BITS + 1,
+])
+def test_fractional_bits_out_of_range_rejected(n, tmp_path):
+    cloud = _cloud(num_points=10)
+    ok, _ = _save(cloud, tmp_path, fractional_bits=n)
+    assert ok is False


### PR DESCRIPTION
# Context

Exposes the position fixed-point precision (`fractionalBits`) as a configurable `PackOption`. The format already encodes `fractionalBits` in [`NgspFileHeader`](https://github.com/nianticlabs/spz/blob/main/src/cc/load-spz.cc) byte 13, and the decoder reads it on every load — so this change is purely encoder-side. Any value the encoder accepts round-trips through every existing decoder; no version bump or format change.

Per-axis representable range is `±2^(23 − fractionalBits)`; resolution is `2^−fractionalBits`:

| N | range | resolution |  |
|---:|---:|---:|---|
| 4 | ±524 288 m | ~6 cm | `MIN_FRACTIONAL_BITS` |
| 8 | ±32 768 m | ~4 mm |  |
| **12** (default) | **±2 048 m** | **~0.24 mm** |  |
| 16 | ±128 m | ~15 µm |  |
| 20 | ±8 m | ~0.95 µm |  |
| 23 | ±1 m | ~0.12 µm | `MAX_FRACTIONAL_BITS` |

Default is unchanged, so all existing callers behave identically.

# Changes

- Add `PackOptions.fractionalBits` (default `12`, range `[MIN_FRACTIONAL_BITS = 4, MAX_FRACTIONAL_BITS = 23]`).
- Out-of-range values are rejected at save time with a logged error, matching the existing `sh1Bits` validation style. The lower bound rules out `N ∈ {0, 1, 2, 3}` — values that give decimeter-or-coarser resolution over thousand-kilometre ranges and have no plausible Gaussian-splat use case.
- Replace the hardcoded `packed.fractionalBits = 12` in `packGaussians` with `o.fractionalBits`.
- Python: `PackOptions.fractional_bits` plus module constants `spz.MIN_FRACTIONAL_BITS`, `spz.MAX_FRACTIONAL_BITS`, `spz.DEFAULT_FRACTIONAL_BITS`.
- README `PackOptions` section updated.

# Test plan

`tests/python/test_pack_options_v4.py` (10 cases, all passing locally; 58 / 58 in the full Python suite):

- **Defaults preserved.** All 48 pre-existing tests pass unchanged. SHA256 of `save_spz` output with default `PackOptions()` is byte-identical to `upstream/main` on both samples (`hornedlizard.spz` → `c5dcc897…2d286`, `racoonfamily.spz` → `1a5d4676…767df`).
- **`fractional_bits` round-trip.** Parametrized over `n ∈ {4, 8, 12, 16, 20, 23}`. Each case asserts:
  - the `fractionalBits` field of `NgspFileHeader` (byte 13: `magic[0..3]`, `version[4..7]`, `numPoints[8..11]`, `shDegree[12]`, `fractionalBits[13]`) echoes the set value;
  - position round-trip max error is `≤ 2^−n`, with input `extent = min(8, 0.5 × 2^(23−n))` so values fit strictly within the representable range — including `n = 23`, where extent collapses to 0.5 and range to ±1.
- **`fractional_bits` rejection.** Parametrized over `{MIN_FRACTIONAL_BITS − 1, 0, MAX_FRACTIONAL_BITS + 1}` — every out-of-range value causes `save_spz` to return `false`.

# Compatibility & relationship to PR #81

This PR does **not** protect against picking a `fractionalBits` value that's *too high* for the cloud's extent — positions outside `±2^(23−N)` silently wrap with the existing encoder. **That bug predates this PR** (any cloud with extent > 2 km already wraps today at the hardcoded `N = 12`) and is fixed in a separate PR: [#81 — Reject positions that overflow the int24 fixed-point range](https://github.com/nianticlabs/spz/pull/81).

The two compose cleanly: with both landed, the encoder rejects out-of-range `fractionalBits` *and* out-of-range positions for whatever `fractionalBits` is in effect. This PR doesn't strictly depend on #81 — it's safe to merge in either order, since #81 also protects existing N=12 callers regardless of whether `fractionalBits` is configurable.

The original draft of this PR also exposed `compressionLevel`. That part has been dropped — without an official format spec the conservative default is to keep encoder output variance small. `fractionalBits` is the part the format already pins via the header field.
