### PR TITLE
[fix] Reject positions that overflow the int24 fixed-point range

### DIFF
--- a/src/cc/load-spz.cc
+++ b/src/cc/load-spz.cc
@@ -361,28 +361,37 @@ PackedGaussians packGaussians(const GaussianCloud &g, const PackOptions &o) {
 #endif
 
   // Store coordinates as 24-bit fixed point values.
-  // Reject any input whose encoded integer falls outside the int24 range
-  // [-2^23, 2^23 - 1]. Without this check, overflow is silently masked to the
-  // low 24 bits and sign-extended on decode, so a coordinate at e.g. 2.5km
-  // with the default fractionalBits=12 (range +/- 2048m) would decode to
-  // about -1.6km. The check operates on the post-rounding integer rather than
-  // |position| directly, which catches the boundary case where rounding tips
-  // a value just below the limit into overflow (e.g. 2047.9999 with N=12).
+  // Reject any input whose encoded value falls outside the int24 range
+  // [-2^23, 2^23 - 1]. Without this check, overflow is silently masked to
+  // the low 24 bits and sign-extended on decode, so a coordinate at e.g.
+  // 2.5km with the default fractionalBits=12 (range +/- 2048m) would decode
+  // to about -1.6km. The check is performed on the post-rounding float
+  // value rather than on |position| directly, which catches the boundary
+  // case where rounding tips a value just below the limit into overflow
+  // (e.g. 2047.9999 with N=12 rounds to 8388608, exceeding the int24 max
+  // of 2^23 - 1). Checking before the static_cast also avoids the
+  // undefined behavior of casting an out-of-range float to int32_t, and
+  // rejects NaN / +-Inf via std::isfinite.
   const float scale = (1 << packed.fractionalBits);
   constexpr int32_t kMaxInt24 = (1 << 23) - 1;
   constexpr int32_t kMinInt24 = -(1 << 23);
+  constexpr float kMaxInt24f = static_cast<float>(kMaxInt24);  // exactly 2^23 - 1
+  constexpr float kMinInt24f = static_cast<float>(kMinInt24);  // exactly -2^23
   for (size_t i = 0; i < numPoints * 3; i++) {
-    const int32_t fixed32 =
-      static_cast<int32_t>(std::round(c.flipP[i % 3] * g.positions[i] * scale));
-    if (fixed32 > kMaxInt24 || fixed32 < kMinInt24) {
-      SpzLog("[SPZ ERROR] position[%zu]=%g overflows the int24 representable "
-             "range at fractionalBits=%d (range: +/- %g). Recenter the cloud "
-             "to keep all positions within range.",
-             i, static_cast<double>(g.positions[i]),
+    const float val =
+      std::round(c.flipP[i % 3] * g.positions[i] * scale);
+    if (!std::isfinite(val) || val > kMaxInt24f || val < kMinInt24f) {
+      static const char kAxisName[3] = {'x', 'y', 'z'};
+      SpzLog("[SPZ ERROR] position point=%zu axis=%c value=%g overflows the "
+             "int24 representable range at fractionalBits=%d (range: +/- %g). "
+             "Recenter the cloud to keep all positions within range.",
+             i / 3, kAxisName[i % 3],
+             static_cast<double>(g.positions[i]),
              static_cast<int>(packed.fractionalBits),
              static_cast<double>(kMaxInt24) / scale);
       return {};
     }
+    const int32_t fixed32 = static_cast<int32_t>(val);
     packed.positions[i * 3 + 0] = fixed32 & 0xff;
     packed.positions[i * 3 + 1] = (fixed32 >> 8) & 0xff;
     packed.positions[i * 3 + 2] = (fixed32 >> 16) & 0xff;

--- a/src/cc/load-spz.cc
+++ b/src/cc/load-spz.cc
@@ -361,10 +361,28 @@ PackedGaussians packGaussians(const GaussianCloud &g, const PackOptions &o) {
 #endif
 
   // Store coordinates as 24-bit fixed point values.
+  // Reject any input whose encoded integer falls outside the int24 range
+  // [-2^23, 2^23 - 1]. Without this check, overflow is silently masked to the
+  // low 24 bits and sign-extended on decode, so a coordinate at e.g. 2.5km
+  // with the default fractionalBits=12 (range +/- 2048m) would decode to
+  // about -1.6km. The check operates on the post-rounding integer rather than
+  // |position| directly, which catches the boundary case where rounding tips
+  // a value just below the limit into overflow (e.g. 2047.9999 with N=12).
   const float scale = (1 << packed.fractionalBits);
+  constexpr int32_t kMaxInt24 = (1 << 23) - 1;
+  constexpr int32_t kMinInt24 = -(1 << 23);
   for (size_t i = 0; i < numPoints * 3; i++) {
     const int32_t fixed32 =
       static_cast<int32_t>(std::round(c.flipP[i % 3] * g.positions[i] * scale));
+    if (fixed32 > kMaxInt24 || fixed32 < kMinInt24) {
+      SpzLog("[SPZ ERROR] position[%zu]=%g overflows the int24 representable "
+             "range at fractionalBits=%d (range: +/- %g). Recenter the cloud "
+             "to keep all positions within range.",
+             i, static_cast<double>(g.positions[i]),
+             static_cast<int>(packed.fractionalBits),
+             static_cast<double>(kMaxInt24) / scale);
+      return {};
+    }
     packed.positions[i * 3 + 0] = fixed32 & 0xff;
     packed.positions[i * 3 + 1] = (fixed32 >> 8) & 0xff;
     packed.positions[i * 3 + 2] = (fixed32 >> 16) & 0xff;

--- a/tests/python/test_position_overflow.py
+++ b/tests/python/test_position_overflow.py
@@ -1,0 +1,92 @@
+"""save_spz must reject positions that overflow the int24 fixed-point range.
+
+Positions are stored as 24-bit signed fixed-point with fractionalBits=12 by
+default, so the per-axis representable range is +/- 2^(23 - 12) = 2048 metres.
+Values outside that range silently wrap (low 24 bits, sign-extended) on
+existing code. This test asserts the encoder now refuses the save instead.
+"""
+import os
+
+import numpy as np
+import pytest
+
+import spz
+
+# The encoder uses fractionalBits = 12. int24 range is [-2^23, 2^23 - 1]
+# so the largest representable input is (2^23 - 1) / 2^12 = 2047.999755859375.
+# Anything strictly larger overflows after rounding.
+MAX_FIXED = (1 << 23) - 1
+MIN_FIXED = -(1 << 23)
+SCALE = 1 << 12
+MAX_SAFE = MAX_FIXED / SCALE       # 2047.999755859375
+MIN_SAFE = MIN_FIXED / SCALE       # -2048.0
+
+
+def _cloud_with_position(x, y=0.0, z=0.0):
+    """Single-point cloud with the given position; everything else zero."""
+    c = spz.GaussianCloud()
+    c.positions = np.array([x, y, z], dtype=np.float32)
+    c.scales = np.zeros(3, dtype=np.float32)
+    c.rotations = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+    c.alphas = np.zeros(1, dtype=np.float32)
+    c.colors = np.zeros(3, dtype=np.float32)
+    return c
+
+
+@pytest.mark.parametrize("v", [
+    MAX_SAFE,                  # exactly the largest representable value
+    MAX_SAFE - 1.0,            # comfortably inside
+    0.0,                       # zero
+    -2048.0,                   # min int24 / 2^12 (signed range is asymmetric)
+    -100.0,
+])
+def test_in_range_positions_save_successfully(v, tmp_path):
+    cloud = _cloud_with_position(v)
+    path = str(tmp_path / "ok.spz")
+    assert spz.save_spz(cloud, spz.PackOptions(), path) is True
+    # Round-trip preserves the value within the quantization step.
+    loaded = spz.load_spz(path)
+    recovered = float(np.asarray(loaded.positions)[0])
+    assert abs(recovered - v) <= 1.0 / SCALE
+
+
+@pytest.mark.parametrize("v", [
+    2048.0,                    # smallest float that overflows int24 after rounding
+    2050.0,                    # comfortably overflowing
+    -2048.001,                 # just past the negative limit (rounds to -8388612)
+    -10000.0,                  # heavy overflow on the negative side
+    1e6,                       # very large
+    -1e6,
+])
+def test_out_of_range_positions_are_rejected(v, tmp_path):
+    cloud = _cloud_with_position(v)
+    path = str(tmp_path / "fail.spz")
+    assert spz.save_spz(cloud, spz.PackOptions(), path) is False
+    # No file on disk on failure.
+    assert not os.path.exists(path) or os.path.getsize(path) == 0
+
+
+def test_rounding_edge_case_rejected(tmp_path):
+    """A value just below the boundary that *rounds up* into overflow must be rejected.
+
+    With fractionalBits=12, scale=4096, the integer ceiling is 8388607. Any
+    float V where round(V * 4096) >= 8388608 overflows; the smallest such V is
+    8388607.5 / 4096 = 2047.9998779296875. The test value below sits right at
+    that boundary -- a naive |V| < 2048 check would miss it.
+    """
+    v = 8388607.5 / SCALE        # rounds to 8388608 (overflows by 1)
+    cloud = _cloud_with_position(v)
+    path = str(tmp_path / "edge.spz")
+    assert spz.save_spz(cloud, spz.PackOptions(), path) is False
+
+
+def test_existing_samples_still_save(tmp_path):
+    """The two repo samples are well within range; they must continue to save."""
+    for name in ["hornedlizard.spz", "racoonfamily.spz"]:
+        sample = f"samples/{name}"
+        if not os.path.exists(sample):
+            pytest.skip(f"sample missing: {sample}")
+        cloud = spz.load_spz(sample)
+        out = str(tmp_path / name)
+        assert spz.save_spz(cloud, spz.PackOptions(), out) is True
+        assert os.path.getsize(out) > 0

--- a/tests/python/test_position_overflow.py
+++ b/tests/python/test_position_overflow.py
@@ -80,6 +80,18 @@ def test_rounding_edge_case_rejected(tmp_path):
     assert spz.save_spz(cloud, spz.PackOptions(), path) is False
 
 
+@pytest.mark.parametrize("v", [
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+])
+def test_nonfinite_positions_are_rejected(v, tmp_path):
+    """NaN and +/- Inf must be rejected; static_cast<int32_t> on them is UB."""
+    cloud = _cloud_with_position(v)
+    path = str(tmp_path / "nonfinite.spz")
+    assert spz.save_spz(cloud, spz.PackOptions(), path) is False
+
+
 def test_existing_samples_still_save(tmp_path):
     """The two repo samples are well within range; they must continue to save."""
     for name in ["hornedlizard.spz", "racoonfamily.spz"]:


### PR DESCRIPTION
# Context

While reviewing how `fractionalBits` would behave if exposed as a configurable `PackOption` (PR #80), I found a silent-corruption bug in the encoder that has been latent since v1.

In [`packGaussians`](https://github.com/nianticlabs/spz/blob/main/src/cc/load-spz.cc), positions are stored as 24-bit signed fixed-point with `fractionalBits = 12` (hardcoded). The per-axis representable range is therefore `[-2^23, 2^23 - 1] / 2^12 = [-2048.0, 2047.999755…] m`. The encoder doesn't clamp or check: any coordinate `V` for which `round(V × 2^N)` falls outside `[-2^23, 2^23 - 1]` produces an `int32` that overflows `int24`. The bottom 24 bits are silently kept, and the decoder sign-extends them. So a value at `+2.5 km` decodes to roughly `-1.6 km` — corrupted output, no error, no warning.

Concrete numerical sanity check: `2500 × 4096 = 10,240,000`; sign-extended low 24 bits = `−6,537,216`; `÷ 4096 = −1596 m`.

The bug hasn't been visible in this library's samples (both `< ±201 m`), but any caller saving a cloud whose extent reaches that boundary produces silently wrong output today.

# Changes

In `packGaussians`, before encoding each coordinate, check the post-rounding **float** value (not the post-cast integer) against the int24 range. On overflow, log a clear error identifying the offending coordinate (`point=N axis=x|y|z value=V`), the `fractionalBits` value, and the actual representable range, then abort the save (returns an empty `PackedGaussians`, causing `save_spz` to return `false`).

Two design notes:

- **The check operates on the post-rounding float**, not on `|V|` directly. This catches the boundary case where a value just under the apparent limit rounds up into overflow — e.g. `V = 2047.9999` with `N = 12` rounds to `8,388,608` which exceeds the int24 max of `2^23 − 1`. A naive `|V| < 2048` check would miss it.
- **The check happens before the `static_cast<int32_t>`**, not after. `static_cast<int32_t>` of a float exceeding `INT32_MAX` is undefined behavior per C++ [`[conv.fpint]/1`](https://eel.is/c++draft/conv.fpint); checking after the cast would rely on platform-specific saturation. The `std::isfinite` guard also rejects `NaN` and `±Inf` (where the cast is UB and naive comparisons return `false`).

# Test plan

`tests/python/test_position_overflow.py` (16 cases, all passing locally; 64/64 in the full Python suite):

- **In-range values save successfully** at the asymmetric int24 boundaries `(2^23 − 1)/2^12 = 2047.999755…` and `−2^23/2^12 = −2048.0`, and round-trip within the quantization step.
- **Out-of-range values are rejected**: `2048.0`, `2050.0`, `−2048.001`, `±10⁴`, `±10⁶`. `save_spz` returns `false`.
- **Rounding-edge case rejected**: `V = 8388607.5 / 4096 = 2047.9998779…` rounds to `8,388,608` which overflows; correctly rejected (a naive `|V| < 2048` check would miss this).
- **Non-finite values rejected**: `NaN`, `+Inf`, `−Inf`. `save_spz` returns `false`.
- **Existing samples still save**: `hornedlizard.spz` and `racoonfamily.spz` are well within `±2 km` and continue to save successfully.

Byte-for-byte equivalence with `upstream/main` verified via SHA256 on both samples (`c5dcc897…2d286`, `1a5d4676…767df`) — the safe-input path is untouched.

# Notes

- The check runs once per coordinate as part of the existing encode loop; cost is negligible.
- This PR does **not** expose `fractionalBits` as configurable. It's a standalone fix for the latent bug at the current default. PR #80 (re-scoped to drop the compression-level part) will rely on this check to make a configurable `fractionalBits` knob safe in both directions.
