### PR TITLE
[android] Including android/log in Header to Prevent Compilation Error + Add Android Build CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,3 +129,39 @@ jobs:
        run: ninja
        working-directory: ./build-wasm
 
+  build-android:
+    name: android ${{ matrix.abi }} SPZ_BUILD_EXTENSIONS=${{ matrix.extensions }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        abi: [arm64-v8a]
+        extensions: [ON, OFF]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r27d
+          add-to-path: false
+
+      - name: Install Ninja
+        run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+      - name: CMake
+        env:
+          SPZ_BUILD_EXTENSIONS: ${{ matrix.extensions }}
+        run: |
+          cmake -G Ninja -B build-android \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_TOOLCHAIN_FILE="${{ steps.setup-ndk.outputs.ndk-path }}/build/cmake/android.toolchain.cmake" \
+            -DANDROID_ABI=${{ matrix.abi }} \
+            -DANDROID_PLATFORM=android-24 \
+            -DSPZ_BUILD_EXTENSIONS=$SPZ_BUILD_EXTENSIONS \
+            -DSPZ_BUILD_TOOLS=OFF \
+            .
+
+      - name: Compile
+        run: cmake --build build-android
+

--- a/src/cc/load-spz.cc
+++ b/src/cc/load-spz.cc
@@ -32,10 +32,6 @@ SOFTWARE.
 #include <zlib.h>
 #include <zstd.h>
 
-#ifdef ANDROID
-#include <android/log.h>
-#endif
-
 #include <algorithm>
 #include <cmath>
 #include <cstring>

--- a/src/cc/load-spz.h
+++ b/src/cc/load-spz.h
@@ -37,6 +37,8 @@ SOFTWARE.
 
 namespace spz {
 #ifdef ANDROID
+#include <android/log.h>
+
 static constexpr char LOG_TAG[] = "SPZ";
 template <class... Args>
 static void SpzLog(const char *fmt, Args &&...args) {


### PR DESCRIPTION
# Context

Was seeing this when building on Android:
```
[ 80%] Building CXX object CMakeFiles/spz.dir/src/cc/load-spz.cc.o
In file included from /Users/lucas/repo/spz/src/cc/load-spz.cc:26:
/Users/lucas/repo/spz/src/cc/load-spz.h:45:23: error: use of undeclared identifier 'ANDROID_LOG_INFO'
   45 |   __android_log_print(ANDROID_LOG_INFO, LOG_TAG, fmt, std::forward<Args>(args)...);
      |                       ^
1 error generated.
make[2]: *** [CMakeFiles/spz.dir/src/cc/load-spz.cc.o] Error 1
make[1]: *** [CMakeFiles/spz.dir/all] Error 2
make: *** [all] Error 2
```

It seems like the `__android_log_print` was moved and the `#includes ...` didn't follow

Added CI for Android

# Test

```
cmake -S . -B build-android \
  -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake" \
  -DANDROID_ABI=arm64-v8a \
  -DANDROID_PLATFORM=android-24
```

Build now works
```
cmake --build build-android
```