### PR TITLE
[fix] Security hardening in the SPZ loader for malformed/untrusted input

### DIFF
--- a/extensions/cc/splat-extensions.cc
+++ b/extensions/cc/splat-extensions.cc
@@ -40,6 +40,18 @@ bool readExact(std::istream& is, T& out) {
 
 // Extension stream format: [u32 type][u32 byteLength][payload...] per record, until EOF.
 // Unknown types are skipped by advancing byteLength bytes so multiple vendors can coexist.
+// Returns the number of bytes remaining between the current get position and the end of `is`,
+// or -1 if the stream does not support positioning. Restores the original position on success.
+std::streamoff remainingBytes(std::istream& is) {
+  const std::streampos cur = is.tellg();
+  if (cur == std::streampos(-1)) return -1;
+  is.seekg(0, std::ios::end);
+  const std::streampos end = is.tellg();
+  is.seekg(cur);
+  if (end == std::streampos(-1)) return -1;
+  return end - cur;
+}
+
 bool tryParseExtension(std::istream& is, std::vector<SpzExtensionBasePtr>& out) {
   uint32_t type_u32{};
   if (!readExact(is, type_u32))
@@ -47,6 +59,15 @@ bool tryParseExtension(std::istream& is, std::vector<SpzExtensionBasePtr>& out) 
   uint32_t byteLength{};
   if (!readExact(is, byteLength))
     return false;
+
+  // Bound byteLength against bytes actually remaining in the stream before any allocation,
+  // so a malformed file cannot drive a multi-GB allocation that the subsequent read would reject.
+  const std::streamoff remaining = remainingBytes(is);
+  if (remaining < 0 || static_cast<uint64_t>(byteLength) > static_cast<uint64_t>(remaining)) {
+    SpzLog("[SPZ ERROR] tryParseExtension: byteLength %u exceeds remaining stream bytes",
+           static_cast<unsigned>(byteLength));
+    return false;
+  }
 
   SpzExtensionType type = static_cast<SpzExtensionType>(type_u32);
 

--- a/src/cc/load-spz.cc
+++ b/src/cc/load-spz.cc
@@ -140,6 +140,22 @@ bool checkSizes(const PackedGaussians &packed, int32_t numPoints, int32_t shDim,
 constexpr uint8_t FlagAntialiased = 0x1;
 constexpr uint8_t FlagHasExtensions = 0x2;
 
+// Generous upper bound on the zstd compression ratio (uncompressed / compressed) used to
+// sanity-check numPoints against the actual file size. Real packed-gaussian streams compress
+// well below this; the bound only exists to reject headers that claim vastly more points than
+// any legitimate file of the given size could contain. Effective ceiling is
+//   maxPoints = (fileSize * kMaxCompressionRatio) / kMinBytesPerPoint
+// Examples (kMaxCompressionRatio=1024, kMinBytesPerPoint=9):
+//   file size      max numPoints accepted
+//      1 KB        ~116 K
+//      1 MB        ~119 M
+//    100 MB        ~11.9 B   (far above any realistic scene)
+//      1 GB        ~119 B    (effectively unlimited)
+// A 32-byte file is capped at ~3.6 K points, so a header claiming billions of points in a
+// tiny file is rejected immediately.
+constexpr size_t kMaxCompressionRatio = 1024;
+constexpr size_t kMinBytesPerPoint = 9;  // positions stream alone: 3 components * 3 bytes
+
 struct NgspFileHeader {
   uint32_t magic          = NGSP_MAGIC;
   uint32_t version        = LATEST_SPZ_HEADER_VERSION;
@@ -738,6 +754,10 @@ bool decompressNgspStreams(const uint8_t *data, size_t size,
     std::memcpy(&infos[i].compressedSize, data + e, sizeof(uint64_t));
     std::memcpy(&infos[i].uncompressedSize, data + e + sizeof(uint64_t), sizeof(uint64_t));
     infos[i].compressedOffset = compressedOffset;
+    if (infos[i].compressedSize > size - compressedOffset) {
+      SpzLog("[SPZ ERROR] decompressNgspStreams: stream extends past end of data");
+      return false;
+    }
     compressedOffset += infos[i].compressedSize;
     if (infos[i].uncompressedSize != dests[i].second) {
       SpzLog("[SPZ ERROR] decompressNgspStreams: stream size mismatch");
@@ -889,8 +909,22 @@ PackedGaussians deserializePackedGaussians(std::istream &in) {
     SpzLog("[SPZ ERROR] deserializePackedGaussians: version not supported: %d", header.version);
     return {};
   }
-  if (header.numPoints <= 0) {
-    SpzLog("[SPZ ERROR] deserializePackedGaussians: invalid point count: %d", header.numPoints);
+  // Bound numPoints against the bytes actually remaining in the decompressed legacy stream.
+  // Legacy files are already gzip-decompressed at this point, so the ratio of header-claimed
+  // points to remaining bytes can't exceed ~1 point per kMinBytesPerPoint bytes.
+  size_t remaining = 0;
+  {
+    const std::streampos cur = in.tellg();
+    if (cur != std::streampos(-1)) {
+      in.seekg(0, std::ios::end);
+      const std::streampos end = in.tellg();
+      in.seekg(cur);
+      if (end != std::streampos(-1)) remaining = static_cast<size_t>(end - cur);
+    }
+  }
+  if (header.numPoints == 0 || (remaining > 0 &&
+      static_cast<size_t>(header.numPoints) > remaining / kMinBytesPerPoint)) {
+    SpzLog("[SPZ ERROR] deserializePackedGaussians: invalid point count: %u", header.numPoints);
     return {};
   }
   if (header.shDegree > SH_MAX_DEGREE) {
@@ -1045,8 +1079,11 @@ PackedGaussians loadSpzPacked(const uint8_t *data, size_t size) {
       SpzLog("[SPZ ERROR] loadSpzPacked: unsupported version: %d", header.version);
       return {};
     }
-    if (header.numPoints == 0) {
-      SpzLog("[SPZ ERROR] loadSpzPacked: invalid point count");
+    if (header.numPoints == 0 ||
+        static_cast<size_t>(header.numPoints) >
+          (size * kMaxCompressionRatio) / kMinBytesPerPoint) {
+      SpzLog("[SPZ ERROR] loadSpzPacked: invalid point count: %u (file size %zu)",
+             header.numPoints, size);
       return {};
     }
     SpzLog(


### PR DESCRIPTION
The security checks in our downstream applications have found several critical concerns in this library. 

In this PR, we make three hardening fixes in the SPZ loader to deal with malformed/untrusted input:

- **Per-stream bounds check in `decompressNgspStreams`** ([src/cc/load-spz.cc](src/cc/load-spz.cc)). The cumulative `compressedOffset != size` check could be bypassed by attacker-controlled per-stream sizes that wrap `size_t` back to `size`, handing `ZSTD_decompress` an out-of-bounds source pointer (segfault, not catchable by the plugin's try/catch). Each stream's range is now validated against the remaining buffer before decompression.

- **`numPoints` validated against file size.** A `uint32_t` header field reaching ~2 × 10⁹ drove a ~40 GB allocation, and casts to `int32_t` made values ≥ 2³¹ wrap negative. `numPoints` is now bounded by `(size × 1024) / 9` — the file-size ceiling under a very generous zstd ratio — so legitimate large scenes pass while tiny files claiming billions of points are rejected. Applied to both NGSP and legacy paths.

- **Extension `byteLength` bounded before allocation** ([extensions/cc/splat-extensions.cc](extensions/cc/splat-extensions.cc)). `tryParseExtension` previously did `std::vector<char> payload(byteLength)` (up to 4 GB) before the bounded read could fail. Now bounded against the bytes remaining in the stream.