### PR TITLE
Add in-memory I/O for python bindings

### DIFF
--- a/src/python/README.md
+++ b/src/python/README.md
@@ -24,6 +24,21 @@ options.from_coord = spz.CoordinateSystem.RUB
 spz.save_spz(cloud, options, "output.spz")
 ```
 
+#### Loading and Saving SPZ In Memory
+
+```python
+import spz
+
+cloud = spz.load_spz("samples/hornedlizard.spz")
+
+# Serialize to bytes instead of writing a file
+data = spz.save_spz_to_buffer(cloud, spz.PackOptions())
+assert isinstance(data, bytes)
+
+# Deserialize from bytes
+roundtrip = spz.load_spz_from_buffer(data, spz.UnpackOptions())
+```
+
 #### Converting PLY to SPZ
 
 ```python

--- a/src/python/spz/spz.cc
+++ b/src/python/spz/spz.cc
@@ -108,6 +108,17 @@ static auto vector_setter = [](std::vector<float>& vec,
         std::memcpy(vec.data(), arr.data(), n * sizeof(float));
 };
 
+// Convert Python bytes to std::vector<uint8_t>.
+static std::vector<uint8_t> bytes_to_vector(const nb::bytes &data) {
+    const auto *begin = reinterpret_cast<const uint8_t *>(data.c_str());
+    return std::vector<uint8_t>(begin, begin + data.size());
+}
+
+// Convert std::vector<uint8_t> to Python bytes.
+static nb::bytes bytes_from_vector(const std::vector<uint8_t> &data) {
+    return nb::bytes(reinterpret_cast<const char *>(data.data()), data.size());
+}
+
 // -----------------------------------------------------------------------------
 // Python module
 // -----------------------------------------------------------------------------
@@ -383,13 +394,42 @@ NB_MODULE(spz, m) {
     // Functions
     // -------------------------------------------------------------------------
 
-    m.def("load_spz", (spz::GaussianCloud (*)(const std::string &, const spz::UnpackOptions &)) &spz::loadSpz,
+        const auto load_spz_from_buffer = [](const nb::bytes &data, const spz::UnpackOptions &options) {
+                return spz::loadSpz(bytes_to_vector(data), options);
+        };
+
+        const auto save_spz_to_buffer = [](const spz::GaussianCloud &gaussians, const spz::PackOptions &options) {
+                std::vector<uint8_t> output;
+                if (!spz::saveSpz(gaussians, options, &output)) {
+                        throw std::runtime_error("Failed to serialize GaussianCloud to SPZ buffer");
+                }
+                return bytes_from_vector(output);
+        };
+
+        m.def("load_spz", (spz::GaussianCloud (*)(const std::string &, const spz::UnpackOptions &)) &spz::loadSpz,
           nb::arg("filename"), nb::arg("options") = spz::UnpackOptions(),
           "Load a *.spz* file and return a GaussianCloud.");
 
     m.def("save_spz", (bool (*)(const spz::GaussianCloud &, const spz::PackOptions &, const std::string &)) &spz::saveSpz,
           nb::arg("gaussians"), nb::arg("options"), nb::arg("filename"),
           "Save a GaussianCloud to a *.spz* file.");
+
+    m.def("load_spz_from_buffer", load_spz_from_buffer,
+          nb::arg("data"), nb::arg("options") = spz::UnpackOptions(),
+          "Load a GaussianCloud from SPZ bytes stored in memory.");
+
+    m.def("save_spz_to_buffer", save_spz_to_buffer,
+          nb::arg("gaussians"), nb::arg("options"),
+          "Serialize a GaussianCloud to SPZ bytes and return a Python bytes object.");
+
+    // Alias names for ergonomics in Python codebases that prefer explicit "bytes" wording.
+    m.def("load_spz_from_bytes", load_spz_from_buffer,
+          nb::arg("data"), nb::arg("options") = spz::UnpackOptions(),
+          "Alias of load_spz_from_buffer().");
+
+    m.def("save_spz_to_bytes", save_spz_to_buffer,
+          nb::arg("gaussians"), nb::arg("options"),
+          "Alias of save_spz_to_buffer().");
 
     m.def("load_splat_from_ply", (spz::GaussianCloud (*)(const std::string &, const spz::UnpackOptions &)) &spz::loadSplatFromPly,
           nb::arg("filename"), nb::arg("options") = spz::UnpackOptions(),

--- a/src/python/spz/spz.cc
+++ b/src/python/spz/spz.cc
@@ -394,19 +394,19 @@ NB_MODULE(spz, m) {
     // Functions
     // -------------------------------------------------------------------------
 
-        const auto load_spz_from_buffer = [](const nb::bytes &data, const spz::UnpackOptions &options) {
-                return spz::loadSpz(bytes_to_vector(data), options);
-        };
+    const auto load_spz_from_buffer = [](const nb::bytes &data, const spz::UnpackOptions &options) {
+        return spz::loadSpz(bytes_to_vector(data), options);
+    };
 
-        const auto save_spz_to_buffer = [](const spz::GaussianCloud &gaussians, const spz::PackOptions &options) {
-                std::vector<uint8_t> output;
-                if (!spz::saveSpz(gaussians, options, &output)) {
-                        throw std::runtime_error("Failed to serialize GaussianCloud to SPZ buffer");
-                }
-                return bytes_from_vector(output);
-        };
+    const auto save_spz_to_buffer = [](const spz::GaussianCloud &gaussians, const spz::PackOptions &options) {
+        std::vector<uint8_t> output;
+        if (!spz::saveSpz(gaussians, options, &output)) {
+            throw std::runtime_error("Failed to serialize GaussianCloud to SPZ buffer");
+        }
+        return bytes_from_vector(output);
+    };
 
-        m.def("load_spz", (spz::GaussianCloud (*)(const std::string &, const spz::UnpackOptions &)) &spz::loadSpz,
+    m.def("load_spz", (spz::GaussianCloud (*)(const std::string &, const spz::UnpackOptions &)) &spz::loadSpz,
           nb::arg("filename"), nb::arg("options") = spz::UnpackOptions(),
           "Load a *.spz* file and return a GaussianCloud.");
 
@@ -421,15 +421,6 @@ NB_MODULE(spz, m) {
     m.def("save_spz_to_buffer", save_spz_to_buffer,
           nb::arg("gaussians"), nb::arg("options"),
           "Serialize a GaussianCloud to SPZ bytes and return a Python bytes object.");
-
-    // Alias names for ergonomics in Python codebases that prefer explicit "bytes" wording.
-    m.def("load_spz_from_bytes", load_spz_from_buffer,
-          nb::arg("data"), nb::arg("options") = spz::UnpackOptions(),
-          "Alias of load_spz_from_buffer().");
-
-    m.def("save_spz_to_bytes", save_spz_to_buffer,
-          nb::arg("gaussians"), nb::arg("options"),
-          "Alias of save_spz_to_buffer().");
 
     m.def("load_splat_from_ply", (spz::GaussianCloud (*)(const std::string &, const spz::UnpackOptions &)) &spz::loadSplatFromPly,
           nb::arg("filename"), nb::arg("options") = spz::UnpackOptions(),

--- a/tests/python/test_io.py
+++ b/tests/python/test_io.py
@@ -79,8 +79,8 @@ def test_save_load_packed_format_in_memory_aliases():
     """Test bytes-named aliases for in-memory SPZ round-trip."""
     src = make_test_gaussian_cloud(include_sh=False)
 
-    data = spz.save_spz_to_bytes(src, spz.PackOptions())
-    dst = spz.load_spz_from_bytes(data, spz.UnpackOptions())
+    data = spz.save_spz_to_buffer(src, spz.PackOptions())
+    dst = spz.load_spz_from_buffer(data, spz.UnpackOptions())
 
     assert dst.num_points == src.num_points
     assert dst.sh_degree == src.sh_degree

--- a/tests/python/test_io.py
+++ b/tests/python/test_io.py
@@ -56,6 +56,37 @@ def test_save_load_packed_format():
     np.testing.assert_allclose(dst.sh[45:45 + 9], src.sh[45:45 + 9], atol=sh_epsilon(5))
 
 
+def test_save_load_packed_format_in_memory_buffer():
+    """Test in-memory SPZ round-trip using bytes buffers."""
+    src = make_test_gaussian_cloud(include_sh=True)
+
+    data = spz.save_spz_to_buffer(src, spz.PackOptions())
+    assert isinstance(data, bytes)
+    assert len(data) > 0
+
+    dst = spz.load_spz_from_buffer(data, spz.UnpackOptions())
+    assert dst.num_points == src.num_points
+    assert dst.sh_degree == src.sh_degree
+    assert dst.antialiased == src.antialiased
+
+    np.testing.assert_allclose(dst.positions, src.positions, atol=1 / 2048.0)
+    np.testing.assert_allclose(dst.scales, src.scales, atol=1 / 32.0)
+    np.testing.assert_allclose(dst.alphas, src.alphas, atol=0.01)
+    np.testing.assert_allclose(dst.sh, src.sh, atol=sh_epsilon(4))
+
+
+def test_save_load_packed_format_in_memory_aliases():
+    """Test bytes-named aliases for in-memory SPZ round-trip."""
+    src = make_test_gaussian_cloud(include_sh=False)
+
+    data = spz.save_spz_to_bytes(src, spz.PackOptions())
+    dst = spz.load_spz_from_bytes(data, spz.UnpackOptions())
+
+    assert dst.num_points == src.num_points
+    assert dst.sh_degree == src.sh_degree
+    np.testing.assert_allclose(dst.positions, src.positions, atol=1 / 2048.0)
+
+
 def test_save_load_packed_format_large_splat():
     """Test saving and loading large SPZ files with many points."""
     num_points = 50000


### PR DESCRIPTION
The C++ core and JavaScript API support saving to/loading from in-memory buffer rather than a file on disc. This PR exposes this capability through the Python API as well!

Also added a bit of doc and a unit test.

Usage:

```python
import spz

cloud = spz.load_spz("samples/hornedlizard.spz")

# Serialize to bytes instead of writing a file
data = spz.save_spz_to_buffer(cloud, spz.PackOptions())
assert isinstance(data, bytes)

# Deserialize from bytes
roundtrip = spz.load_spz_from_buffer(data, spz.UnpackOptions())
```