### PR TITLE
Add GitHub workflow to share build artifacts for major platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,11 +35,11 @@ jobs:
             msvc_arch: arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Configure MSVC environment
         if: startsWith(matrix.runner, 'windows-')
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
         with:
           arch: ${{ matrix.msvc_arch }}
 
@@ -54,7 +54,7 @@ jobs:
         run: cmake --build build --config Release --target spz --parallel
 
       - name: Upload C++ artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: cpp-${{ matrix.name }}
           path: |
@@ -69,8 +69,8 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: emscripten-core/setup-emsdk@v16
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: emscripten-core/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
 
       - name: Configure
         run: >
@@ -83,7 +83,7 @@ jobs:
         run: cmake --build build-wasm --target spz-wasm --parallel
 
       - name: Upload wasm artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: cpp-wasm
           path: |
@@ -120,16 +120,16 @@ jobs:
             msvc_arch: arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Configure MSVC environment
         if: startsWith(matrix.runner, 'windows-')
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
         with:
           arch: ${{ matrix.msvc_arch }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
           architecture: ${{ matrix.py_arch }}
@@ -142,7 +142,7 @@ jobs:
           python -m pip wheel . -w wheelhouse
 
       - name: Upload wheel artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: python-${{ matrix.name }}
           path: wheelhouse/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,138 @@
+name: Build Multi-Platform
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-cpp-native:
+    name: C++ ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x64
+            runner: ubuntu-24.04
+          - name: linux-arm64
+            runner: ubuntu-24.04-arm
+          - name: macos-x64
+            runner: macos-13
+          - name: macos-arm64
+            runner: macos-14
+          - name: windows-x64
+            runner: windows-2022
+          - name: windows-arm64
+            runner: windows-11-arm
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure MSVC environment
+        if: startsWith(matrix.runner, 'windows-')
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Configure
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DSPZ_BUILD_TOOLS=OFF \
+            -DSPZ_BUILD_PYTHON_BINDINGS=OFF
+
+      - name: Build library
+        run: cmake --build build --config Release --target spz --parallel
+
+      - name: Upload C++ artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpp-${{ matrix.name }}
+          path: |
+            build/**/*.a
+            build/**/*.lib
+            build/**/*.so
+            build/**/*.dylib
+            build/**/spz*
+
+  build-wasm:
+    name: C++ wasm
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: emscripten-core/setup-emsdk@v16
+
+      - name: Configure
+        run: |
+          emcmake cmake -S . -B build-wasm \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DSPZ_BUILD_TOOLS=OFF \
+            -DSPZ_BUILD_EXTENSIONS=ON
+
+      - name: Build wasm target
+        run: cmake --build build-wasm --target spz-wasm --parallel
+
+      - name: Upload wasm artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpp-wasm
+          path: |
+            dist/spz.js
+            dist/spz.wasm
+            dist/spz.d.ts
+
+  build-python-libs:
+    name: Python lib ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x64
+            runner: ubuntu-24.04
+            py_arch: x64
+          - name: linux-arm64
+            runner: ubuntu-24.04-arm
+            py_arch: arm64
+          - name: macos-x64
+            runner: macos-13
+            py_arch: x64
+          - name: macos-arm64
+            runner: macos-14
+            py_arch: arm64
+          - name: windows-x64
+            runner: windows-2022
+            py_arch: x64
+          - name: windows-arm64
+            runner: windows-11-arm
+            py_arch: arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure MSVC environment
+        if: startsWith(matrix.runner, 'windows-')
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          architecture: ${{ matrix.py_arch }}
+
+      - name: Build wheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip wheel . -w wheelhouse
+
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-${{ matrix.name }}
+          path: wheelhouse/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Multi-Platform
+name: Build
 
 on:
   push:
@@ -40,10 +40,10 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Configure
-        run: |
-          cmake -S . -B build \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DSPZ_BUILD_TOOLS=OFF \
+        run: >
+          cmake -S . -B build
+            -DCMAKE_BUILD_TYPE=Release
+            -DSPZ_BUILD_TOOLS=OFF
             -DSPZ_BUILD_PYTHON_BINDINGS=OFF
 
       - name: Build library
@@ -69,10 +69,10 @@ jobs:
       - uses: emscripten-core/setup-emsdk@v16
 
       - name: Configure
-        run: |
-          emcmake cmake -S . -B build-wasm \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DSPZ_BUILD_TOOLS=OFF \
+        run: >
+          emcmake cmake -S . -B build-wasm
+            -DCMAKE_BUILD_TYPE=Release
+            -DSPZ_BUILD_TOOLS=OFF
             -DSPZ_BUILD_EXTENSIONS=ON
 
       - name: Build wasm target
@@ -127,8 +127,10 @@ jobs:
           architecture: ${{ matrix.py_arch }}
 
       - name: Build wheel
-        run: |
-          python -m pip install --upgrade pip
+        env:
+          CMAKE_ARGS: -DCMAKE_DISABLE_FIND_PACKAGE_zstd=ON -DSPZ_BUILD_TOOLS=OFF
+        run: >-
+          python -m pip install --upgrade pip &&
           python -m pip wheel . -w wheelhouse
 
       - name: Upload wheel artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,10 @@ jobs:
             runner: macos-14
           - name: windows-x64
             runner: windows-2022
+            msvc_arch: x64
           - name: windows-arm64
             runner: windows-11-arm
+            msvc_arch: arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -38,13 +40,15 @@ jobs:
       - name: Configure MSVC environment
         if: startsWith(matrix.runner, 'windows-')
         uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.msvc_arch }}
 
       - name: Configure
         run: >
           cmake -S . -B build
-            -DCMAKE_BUILD_TYPE=Release
-            -DSPZ_BUILD_TOOLS=OFF
-            -DSPZ_BUILD_PYTHON_BINDINGS=OFF
+          -DCMAKE_BUILD_TYPE=Release
+          -DSPZ_BUILD_TOOLS=OFF
+          -DSPZ_BUILD_PYTHON_BINDINGS=OFF
 
       - name: Build library
         run: cmake --build build --config Release --target spz --parallel
@@ -71,9 +75,9 @@ jobs:
       - name: Configure
         run: >
           emcmake cmake -S . -B build-wasm
-            -DCMAKE_BUILD_TYPE=Release
-            -DSPZ_BUILD_TOOLS=OFF
-            -DSPZ_BUILD_EXTENSIONS=ON
+          -DCMAKE_BUILD_TYPE=Release
+          -DSPZ_BUILD_TOOLS=OFF
+          -DSPZ_BUILD_EXTENSIONS=ON
 
       - name: Build wasm target
         run: cmake --build build-wasm --target spz-wasm --parallel
@@ -109,9 +113,11 @@ jobs:
           - name: windows-x64
             runner: windows-2022
             py_arch: x64
+            msvc_arch: x64
           - name: windows-arm64
             runner: windows-11-arm
             py_arch: arm64
+            msvc_arch: arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -119,6 +125,8 @@ jobs:
       - name: Configure MSVC environment
         if: startsWith(matrix.runner, 'windows-')
         uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.msvc_arch }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Providing pre-compiled artifacts could easily ease up adoption, especially for audiences who only need the WASM build or python modules (which might not be fluent at CMake, or willing to set it up even if the project did a good job at keeping dependencies simple).

This is a first attempt at providing precompiled artifacts, if there is interest I can also add the possibility to automatically create a release with said artifacts attached to it already. I did not do it yet because I don't know if you already have a release process in place.