### PR TITLE
[fix] Add missing find_dependency(zstd) to CMake package config

### DIFF
--- a/cmake/spzConfig.cmake.in
+++ b/cmake/spzConfig.cmake.in
@@ -3,6 +3,7 @@
 if(NOT "@BUILD_SHARED_LIBS@")
     include(CMakeFindDependencyMacro)
     find_dependency(ZLIB)
+    find_dependency(zstd)
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/spzConfigVersion.cmake)


### PR DESCRIPTION
Consumers of exported targets need to locate all transitive link dependencies. ZLIB was already declared but zstd was missing, causing downstream find_package(spz) would fail because zstd targets are missing