### PR TITLE
[CMAKE] Set up Logic for 2GB and 4GB WASM Packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,9 @@ set_target_properties(spz PROPERTIES
 )
 
 if(SPZ_BUILD_WASM)
-  file(MAKE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/dist")
+  set(spz_wasm_variants "small" "large")
+  set(spz_wasm_small_max_memory "2147483648")  # 2 GB
+  set(spz_wasm_large_max_memory "4294967296")  # 4 GB
 
   set(spz_binding_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/src/emscripten/spz-bindings.cc"
@@ -153,36 +155,6 @@ if(SPZ_BUILD_WASM)
     )
   endif()
 
-  add_executable(spz-wasm ${spz_binding_sources})
-  target_link_libraries(spz-wasm PRIVATE spz)
-
-  if(SPZ_BUILD_EXTENSIONS)
-    target_include_directories(spz-wasm PRIVATE
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    )
-  endif()
-
-  target_link_options(spz-wasm PRIVATE
-    "-O3"
-    "-sUSE_ZLIB=1"
-    "--bind"
-    "-sMODULARIZE=1"
-    "-sEXPORT_NAME=createSpzModule"
-    "-sALLOW_MEMORY_GROWTH=1"
-    "-sMAXIMUM_MEMORY=4294967296"
-    "-sENVIRONMENT=web"
-    "-sEXPORT_ES6=1"
-    "-sSINGLE_FILE=1"
-    "-sEXPORTED_RUNTIME_METHODS=[\"ccall\",\"cwrap\",\"HEAPU8\"]"
-    "-sEXPORTED_FUNCTIONS=[\"_malloc\",\"_free\"]"
-  )
-
-  set_target_properties(spz-wasm PROPERTIES
-    OUTPUT_NAME "spz"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/dist"
-  )
-
-  # Generate the TypeScript declaration file conditionally based on SPZ_BUILD_EXTENSIONS
   if(SPZ_BUILD_EXTENSIONS)
     # Read the extensions TypeScript definitions
     file(READ "${CMAKE_CURRENT_SOURCE_DIR}/extensions/emscripten/splat-extensions.d.ts.in" SPZ_EXTENSIONS_TYPESCRIPT_DEFINITIONS)
@@ -194,29 +166,64 @@ if(SPZ_BUILD_WASM)
     set(SPZ_EXTENSIONS_MODULE_INTERFACE "")
   endif()
 
-  configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/emscripten/spz.d.ts.in"
-    "${CMAKE_CURRENT_SOURCE_DIR}/dist/spz.d.ts"
-    @ONLY
-  )
+  foreach(variant IN LISTS spz_wasm_variants)
+    set(variant_dir "${CMAKE_CURRENT_SOURCE_DIR}/dist/${variant}")
+    file(MAKE_DIRECTORY "${variant_dir}")
 
-  configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/emscripten/spz-helpers.js"
-    "${CMAKE_CURRENT_SOURCE_DIR}/dist/spz-helpers.js"
-    COPYONLY
-  )
-  configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/emscripten/spz-helpers.d.ts"
-    "${CMAKE_CURRENT_SOURCE_DIR}/dist/spz-helpers.d.ts"
-    COPYONLY
-  )
+    set(variant_target "spz-wasm-${variant}")
+    add_executable(${variant_target} ${spz_binding_sources})
+    target_link_libraries(${variant_target} PRIVATE spz)
 
-  add_custom_target(copy_spz_dts ALL
-    DEPENDS
-      "${CMAKE_CURRENT_SOURCE_DIR}/dist/spz.d.ts"
-      "${CMAKE_CURRENT_SOURCE_DIR}/dist/spz-helpers.js"
-      "${CMAKE_CURRENT_SOURCE_DIR}/dist/spz-helpers.d.ts"
-  )
+    if(SPZ_BUILD_EXTENSIONS)
+      target_include_directories(${variant_target} PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+      )
+    endif()
+
+    target_link_options(${variant_target} PRIVATE
+      "-O3"
+      "-sUSE_ZLIB=1"
+      "--bind"
+      "-sMODULARIZE=1"
+      "-sEXPORT_NAME=createSpzModule"
+      "-sALLOW_MEMORY_GROWTH=1"
+      "-sMAXIMUM_MEMORY=${spz_wasm_${variant}_max_memory}"
+      "-sENVIRONMENT=web"
+      "-sEXPORT_ES6=1"
+      "-sSINGLE_FILE=1"
+      "-sEXPORTED_RUNTIME_METHODS=[\"ccall\",\"cwrap\",\"HEAPU8\"]"
+      "-sEXPORTED_FUNCTIONS=[\"_malloc\",\"_free\"]"
+    )
+
+    set_target_properties(${variant_target} PROPERTIES
+      OUTPUT_NAME "spz"
+      RUNTIME_OUTPUT_DIRECTORY "${variant_dir}"
+    )
+
+    configure_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/emscripten/spz.d.ts.in"
+      "${variant_dir}/spz.d.ts"
+      @ONLY
+    )
+
+    configure_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/emscripten/spz-helpers.js"
+      "${variant_dir}/spz-helpers.js"
+      COPYONLY
+    )
+    configure_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/emscripten/spz-helpers.d.ts"
+      "${variant_dir}/spz-helpers.d.ts"
+      COPYONLY
+    )
+
+    add_custom_target(copy_spz_dts_${variant} ALL
+      DEPENDS
+        "${variant_dir}/spz.d.ts"
+        "${variant_dir}/spz-helpers.js"
+        "${variant_dir}/spz-helpers.d.ts"
+    )
+  endforeach()
 endif()
 
 # Installation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,9 +140,11 @@ set_target_properties(spz PROPERTIES
 )
 
 if(SPZ_BUILD_WASM)
-  set(spz_wasm_variants "small" "large")
-  set(spz_wasm_small_max_memory "2147483648")  # 2 GB
-  set(spz_wasm_large_max_memory "4294967296")  # 4 GB
+  set(spz_wasm_variants "2gb" "4gb")
+  set(spz_wasm_2gb_max_memory "2147483648")               # 2 GB (default; historical single-variant behavior)
+  set(spz_wasm_4gb_max_memory "4294967296")               # 4 GB (wasm32 address-space ceiling)
+  set(spz_wasm_2gb_dir "${CMAKE_CURRENT_SOURCE_DIR}/dist")  # default build stays at dist/ root
+  set(spz_wasm_4gb_dir "${CMAKE_CURRENT_SOURCE_DIR}/dist/4gb")
 
   set(spz_binding_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/src/emscripten/spz-bindings.cc"
@@ -167,7 +169,7 @@ if(SPZ_BUILD_WASM)
   endif()
 
   foreach(variant IN LISTS spz_wasm_variants)
-    set(variant_dir "${CMAKE_CURRENT_SOURCE_DIR}/dist/${variant}")
+    set(variant_dir "${spz_wasm_${variant}_dir}")
     file(MAKE_DIRECTORY "${variant_dir}")
 
     set(variant_target "spz-wasm-${variant}")

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Then one can build through
 ```
 cmake --build build-wasm
 ```
-The package will be built and installed into the `dist` folder.
+The package will be built and installed into the `dist` folder. Two WASM variants are emitted: `dist/small` (2 GB memory ceiling, the default) and `dist/large` (4 GB ceiling, for very large splats). They share the same API and TypeScript declarations.
 
 
 ## API

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Then one can build through
 ```
 cmake --build build-wasm
 ```
-The package will be built and installed into the `dist` folder. Two WASM variants are emitted: `dist/small` (2 GB memory ceiling, the default) and `dist/large` (4 GB ceiling, for very large splats). They share the same API and TypeScript declarations.
+The package will be built and installed into the `dist` folder. Two WASM variants are emitted: the default build in `dist/` (2 GB memory ceiling) and `dist/4gb` (4 GB ceiling, for very large splats). They share the same API and TypeScript declarations.
 
 
 ## API


### PR DESCRIPTION
# Context

Refactors the SPZ_BUILD_WASM section of CMakeLists.txt to build the Emscripten bindings twice.

This prepares the `dist/ `layout for publishing the WASM build as an npm package (via the adobe/spz mirror), where the 4 GB build will be exposed as an opt-in `@adobe/spz/4gb` subpath export while the default . export keeps the exact paths the published 0.2.2 package uses.

# Test

Verified both variants build and link to their expected paths (`dist/spz.js`, `dist/4gb/spz.js`) and that the linker
  receives the correct per-variant MAXIMUM_MEMORY value.